### PR TITLE
widen ghost hunt gates and add contract sanity drain

### DIFF
--- a/passages/StoryScript.tw
+++ b/passages/StoryScript.tw
@@ -1281,6 +1281,17 @@ setup.HauntConditions = (function () {
             contributors:      []
         };
 
+        if (inHouse) {
+            var hasCompanion = V.isCompChosen === 1;
+            var contractDrain = hasCompanion ? 0.2 : 0.4;
+            snap.sanityPerStep -= contractDrain;
+            snap.contributors.push({
+                label: hasCompanion ? "Contract (w/ companion)" : "Contract",
+                color: "#cc8866",
+                detail: "sanity −" + contractDrain + "/step"
+            });
+        }
+
         if (isCurrentRoomDark()) {
             snap.dark = true;
             snap.sanityPerStep  -= 1;

--- a/passages/ghosts/GhostController.tw
+++ b/passages/ghosts/GhostController.tw
@@ -31,8 +31,8 @@
             evidence: [E.EMF, E.GWB, E.TEMPERATURE],
             hint: "The lower your sanity, the less likely the Shade is to show interest in you.",
             description: "Shade -- one of the oldest types of ghosts. The main feature of the Shade is that the lower your sanity, the less likely the Shade is to show interest in you.",
-            huntCondition:     function (mc) { return mc.sanity <= 35; },
-            huntConditionText: "Can start a hunt if you have <= 35 sanity",
+            huntCondition:     function (mc) { return mc.sanity <= 55; },
+            huntConditionText: "Can start a hunt if you have <= 55 sanity",
             invertedSanityStages: true
         },
         {
@@ -40,8 +40,8 @@
             evidence: [E.EMF, E.SPIRITBOX, E.GWB],
             hint: "If it doesn't achieve its goal, it will relentlessly follow its victim.",
             description: "Spirit is a rather shy ghost. Unlike others, if it doesn't achieve its goal, it will relentlessly follow its victim. However, once it gets what it wants, it will vanish and cease to disturb, leaving its target in peace.",
-            huntCondition:     function (mc) { return mc.lust >= 50; },
-            huntConditionText: "Can start a hunt if you have >= 50 lust",
+            huntCondition:     function (mc) { return mc.lust >= 30; },
+            huntConditionText: "Can start a hunt if you have >= 30 lust",
             walkHomePassage:   "GhostSpecialEventSpirit",
             onHuntEnd:         function () { State.variables.ghostSpiritEventStage = 0; }
         },
@@ -50,16 +50,16 @@
             evidence: [E.SPIRITBOX, E.GWB, E.UVL],
             hint: "",
             description: "",
-            huntCondition:     function (mc) { return mc.sanity <= 50; },
-            huntConditionText: "Can start a hunt if you have <= 50 sanity"
+            huntCondition:     function (mc) { return mc.sanity <= 70; },
+            huntConditionText: "Can start a hunt if you have <= 70 sanity"
         },
         {
             name: "Phantom", image: "phantom.webp",
             evidence: [E.GLASS, E.UVL, E.SPIRITBOX],
             hint: "This type of ghost cannot turn off the lights.",
             description: "This type of ghost cannot turn off the lights.",
-            huntCondition:     function (mc) { return mc.sanity <= 50; },
-            huntConditionText: "Can start a hunt if you have <= 50 sanity",
+            huntCondition:     function (mc) { return mc.sanity <= 70; },
+            huntConditionText: "Can start a hunt if you have <= 70 sanity",
             canTurnOffLights:  false
         },
         {
@@ -67,18 +67,18 @@
             evidence: [E.GLASS, E.UVL, E.EMF],
             hint: "Goryo is known for its attachment to a single room and cannot change it like other ghosts do.",
             description: "Goryo is known for its attachment to a single room and cannot change it like other ghosts do. If you notice that the ghost's activity is focused exclusively in one area, you are likely dealing with a Goryo.",
-            huntCondition:     function (mc) { return mc.lust >= 50; },
-            huntConditionText: "Can start a hunt if you have >= 50 lust",
+            huntCondition:     function (mc) { return mc.lust >= 30; },
+            huntConditionText: "Can start a hunt if you have >= 30 lust",
             staysInOneRoom:    true
         },
         {
             name: "Demon", image: "demon.webp",
             evidence: [E.GWB, E.UVL, E.TEMPERATURE],
             hint: "Demon can start a hunt earlier than other ghosts",
-            description: "Some sources report that the Demon is a unique ghost that can begin hunting you regardless of your current sanity or lust. Unlike other ghosts that only become active when your mental state declines or your desire increases, the Demon does not consider your present condition and can initiate its pursuit at any time.",
+            description: "Some sources report that the Demon is a unique ghost that can begin hunting you regardless of your current sanity or lust. Unlike other ghosts that only become active when your mental state declines or your desire increases, the Demon does not so strongly consider your present condition and can initiate its pursuit at nearly any time.",
             findableOnline: true,
-            huntCondition:     function (mc) { return mc.sanity <= 70; },
-            huntConditionText: "Can start a hunt if you have <= 70 sanity"
+            huntCondition:     function (mc) { return mc.sanity <= 90; },
+            huntConditionText: "Can start a hunt if you have <= 90 sanity"
         },
         {
             name: "Deogen", image: "deogen.webp",
@@ -86,8 +86,8 @@
             hint: "When it starts its hunt, hiding won't help, as the Deogen relentlessly searches for you",
             description: "The Deogen is described as a particularly frightening ghost that will always find you, even if you try to hide. Once it starts its hunt, hiding won't help, as the Deogen relentlessly searches for its prey. However, since the Deogen is extremely slow, there's a chance to escape if you still have the strength to run.",
             findableOnline: true,
-            huntCondition:     function (mc) { return mc.sanity <= 50; },
-            huntConditionText: "Can start a hunt if you have <= 50 sanity",
+            huntCondition:     function (mc) { return mc.sanity <= 70; },
+            huntConditionText: "Can start a hunt if you have <= 70 sanity",
             hidingSucceeds:    false,   // Deogen always finds you
             runningSucceeds:   true     // …but you can outrun it
         },
@@ -97,8 +97,8 @@
             hint: "You can't escape from the Jinn by running, as it is incredibly fast.",
             description: "Some ghost hunters have reported that when encountering a Jinn, they tried to run but always failed because the ghost is too fast. However, when they found a hiding spot--even if it was right in front of the Jinn--he often passed by without noticing them. This indicates that hiding from a Jinn is much easier than trying to escape.",
             findableOnline: true,
-            huntCondition:     function (mc) { return mc.sanity <= 50; },
-            huntConditionText: "Can start a hunt if you have <= 50 sanity",
+            huntCondition:     function (mc) { return mc.sanity <= 70; },
+            huntConditionText: "Can start a hunt if you have <= 70 sanity",
             hidingSucceeds:    true,    // Jinn can be hidden from
             runningSucceeds:   false    // …but never outrun
         },
@@ -107,8 +107,8 @@
             evidence: [E.GWB, E.TEMPERATURE, E.SPIRITBOX],
             hint: "",
             description: "The Moroi can invade the minds of weak-willed victims when using the Spirit Box. Be cautious when communicating, as this ghost may possess you.",
-            huntCondition:           function (mc) { return mc.sanity <= 50; },
-            huntConditionText:       "Can start a hunt if you have <= 50 sanity",
+            huntCondition:           function (mc) { return mc.sanity <= 70; },
+            huntConditionText:       "Can start a hunt if you have <= 70 sanity",
             spiritboxPossessionChance: 30
         },
         {
@@ -116,8 +116,8 @@
             evidence: [E.GWB, E.EMF, E.UVL],
             hint: "Once you leave its presence, strange things begin to happen: those around you start seeing you in unusual clothing or even completely naked.",
             description: "Myling is a ghost that doesn't reveal itself directly upon encounter. However, once you leave its presence, strange things begin to happen: those around you start seeing you in unusual clothing or even completely naked.",
-            huntCondition:     function (mc) { return mc.lust >= 50; },
-            huntConditionText: "Can start a hunt if you have >= 50 lust",
+            huntCondition:     function (mc) { return mc.lust >= 30; },
+            huntConditionText: "Can start a hunt if you have >= 30 lust",
             goHomePassage:        "GhostSpecialEventMyling",
             companionHuntPassage: "GhostSpecialEventMylingTwo"
         },
@@ -127,8 +127,8 @@
             hint: "Encountering this ghost causes sanity to drop faster than with other ghosts.",
             description: "The mythical entity Oni brings not only fear but also rapid psychological devastation. Those who have encountered it report that @@.notmc-speech;Oni causes a sharp and intense decline in sanity@@, significantly accelerating this process compared to other ghosts. If you come face-to-face with Oni, be prepared for a swift and severe assault on your mental health.",
             findableOnline: true,
-            huntCondition:     function (mc) { return mc.lust >= 50; },
-            huntConditionText: "Can start a hunt if you have >= 50 lust",
+            huntCondition:     function (mc) { return mc.lust >= 30; },
+            huntConditionText: "Can start a hunt if you have >= 30 lust",
             sanityEventLossRange: [3, 8]
         },
         {
@@ -136,8 +136,8 @@
             evidence: [E.UVL, E.TEMPERATURE, E.SPIRITBOX],
             hint: "Mimic always has an extra evidence -- ectoplasm",
             description: "Mimic is a ghost that can mimic nearly all the abilities of other ghosts, making it extremely unpredictable and difficult to identify. Additionally, The Mimic always has an extra evidence -- ectoplasm. Although ectoplasm is not considered evidence for identifying the ghost, its presence can aid in its identification.",
-            huntCondition:     function (mc) { return mc.sanity <= 50; },
-            huntConditionText: "Can start a hunt if you have <= 50 sanity",
+            huntCondition:     function (mc) { return mc.sanity <= 70; },
+            huntConditionText: "Can start a hunt if you have <= 70 sanity",
             onEnterHouse: function () {
                 /* Seed the rotation clock; realName is already "Mimic"
                    from startHunt, so isMimicHunt() already returns true. */
@@ -149,8 +149,8 @@
             evidence: [E.EMF, E.TEMPERATURE, E.SPIRITBOX],
             hint: "",
             description: "",
-            huntCondition:     function (mc) { return mc.lust >= 50; },
-            huntConditionText: "Can start a hunt if you have >= 50 lust",
+            huntCondition:     function (mc) { return mc.lust >= 30; },
+            huntConditionText: "Can start a hunt if you have >= 30 lust",
             huntEventFlag:     "thetwinsevent"
         },
         {
@@ -158,8 +158,8 @@
             evidence: [E.GLASS, E.EMF, E.SPIRITBOX],
             hint: "If caught or if sanity runs out during the ghost hunt, you'll wake up somewhere other than home.",
             description: "This is quite a dangerous ghost. If it catches me or I lose sanity during the ghost hunt... Ending up in the forest with my hands tied is not something I want, so I need to be very careful. But even if things don't go as planned, it's better to conserve my energy to have a chance to escape.",
-            huntCondition:     function (mc) { return mc.lust >= 50; },
-            huntConditionText: "Can start a hunt if you have >= 50 lust",
+            huntCondition:     function (mc) { return mc.lust >= 30; },
+            huntConditionText: "Can start a hunt if you have >= 30 lust",
             sleepPassage:      "GhostSpecialEventWraith"
         },
         {
@@ -167,8 +167,8 @@
             evidence: [E.GLASS, E.GWB, E.TEMPERATURE],
             hint: "Mare visits your house while you sleep",
             description: "Mare visits my house while I sleep. It's quite easy to get rid of; I just need to sprinkle holy water in the room where I sleep. It becomes more aggressive each day, so it's best not to delay. Although, someone online mentioned that it might stop haunting after a few days.",
-            huntCondition:     function (mc) { return mc.lust >= 50; },
-            huntConditionText: "Can start a hunt if you have >= 50 lust",
+            huntCondition:     function (mc) { return mc.lust >= 30; },
+            huntConditionText: "Can start a hunt if you have >= 30 lust",
             onEnterHouse: function () {
                 var V = State.variables;
                 if (V.ghostMareEventStart === 0) {
@@ -183,8 +183,8 @@
             evidence: [E.SPIRITBOX, E.GLASS, E.TEMPERATURE],
             hint: "Cthulion rarely reveals its true form, preferring to take on a human appearance. But when it needs to interact with its victims, it's not above using its tentacles.",
             description: "Cthulion is one of the oldest beings, with a history stretching far back before the dawn of humanity. Its true form is so alien to the human mind that most who encounter it can only describe it as \"unspeakable.\" However, Cthulion rarely reveals its true form, preferring to take on a human appearance. But when it needs to interact with its victims, it's not above using its tentacles.",
-            huntCondition:     function (mc) { return mc.sanity <= 50; },
-            huntConditionText: "Can start a hunt if you have <= 50 sanity",
+            huntCondition:     function (mc) { return mc.sanity <= 70; },
+            huntConditionText: "Can start a hunt if you have <= 70 sanity",
             canTentacles: true,
             cursedActivityVideos: [
                 "ghosts/cthulion/1.0.mp4", "ghosts/cthulion/1.1.mp4",
@@ -200,8 +200,8 @@
             evidence: [E.GLASS, E.GWB, E.UVL],
             hint: "The Banshee has a unique ability called the 'Kiss of the Banshee,' which reduces sanity by 10 points.",
             description: "The Banshee has a unique ability called the \"Kiss of the Banshee,\" which reduces sanity by 10 points.",
-            huntCondition:     function (mc) { return mc.lust >= 50; },
-            huntConditionText: "Can start a hunt if you have >= 50 lust",
+            huntCondition:     function (mc) { return mc.lust >= 30; },
+            huntConditionText: "Can start a hunt if you have >= 30 lust",
             canKiss: true,
             cursedActivityVideos: [
                 "ghosts/banshee/1.mp4", "ghosts/banshee/2.mp4",
@@ -216,8 +216,8 @@
             evidence: [E.EMF, E.SPIRITBOX, E.UVL],
             hint: "Raiju is a mysterious entity that occasionally exerts influence over electrical devices, causing them to display incorrect readings. This spectral presence can manipulate the behavior of electronics, leading to unpredictable and sometimes inexplicable malfunctions.",
             description: "Raiju is a mysterious entity that occasionally exerts influence over electrical devices, causing them to display incorrect readings. This spectral presence can manipulate the behavior of electronics, leading to unpredictable and sometimes inexplicable malfunctions.",
-            huntCondition:           function (mc) { return mc.sanity <= 50; },
-            huntConditionText:       "Can start a hunt if you have <= 50 sanity",
+            huntCondition:           function (mc) { return mc.sanity <= 70; },
+            huntConditionText:       "Can start a hunt if you have <= 70 sanity",
             emfGlitchChance:         3,
             temperatureGlitchChance: 8,
             spiritboxStaticChance:   20

--- a/sim_ai_hunt.py
+++ b/sim_ai_hunt.py
@@ -47,106 +47,361 @@ Usage:
 from __future__ import annotations
 
 import random
+import re
 import sys
 from dataclasses import dataclass, field
+from pathlib import Path
 
 
-ELM_ROOMS = [
-    "kitchen", "bathroom", "bedroom", "nursery", "hallway",
-    "hallwayUpstairs", "bedroomTwo", "bathroomTwo", "basement",
-]
+# ---- Game-data loader ------------------------------------------------
+#
+# Everything in this section parses numbers/flags straight from the game's
+# .tw source. The AI below consumes these values; nothing that affects
+# mechanics is hardcoded.
 
-# Evidence triples from GhostController.tw. Mimic's "extra glass" bonus is
-# ignored here (the simulation identifies by the canonical triple).
-GHOST_EVIDENCE: dict[str, frozenset[str]] = {
-    "Shade":       frozenset({"emf", "gwb", "temperature"}),
-    "Spirit":      frozenset({"emf", "spiritbox", "gwb"}),
-    "Poltergeist": frozenset({"spiritbox", "gwb", "uvl"}),
-    "Phantom":     frozenset({"glass", "uvl", "spiritbox"}),
-    "Goryo":       frozenset({"glass", "uvl", "emf"}),
-    "Demon":       frozenset({"gwb", "uvl", "temperature"}),
-    "Deogen":      frozenset({"glass", "gwb", "spiritbox"}),
-    "Jinn":        frozenset({"emf", "uvl", "temperature"}),
-    "Moroi":       frozenset({"gwb", "temperature", "spiritbox"}),
-    "Myling":      frozenset({"gwb", "emf", "uvl"}),
-    "Oni":         frozenset({"glass", "emf", "temperature"}),
-    "Mimic":       frozenset({"uvl", "temperature", "spiritbox"}),
-    "The Twins":   frozenset({"emf", "temperature", "spiritbox"}),
-    "Wraith":      frozenset({"glass", "emf", "spiritbox"}),
-    "Mare":        frozenset({"glass", "gwb", "temperature"}),
-    "Cthulion":    frozenset({"spiritbox", "glass", "temperature"}),
-    "Banshee":     frozenset({"glass", "gwb", "uvl"}),
-    "Raiju":       frozenset({"emf", "spiritbox", "uvl"}),
+
+REPO_ROOT = Path(__file__).resolve().parent
+PASSAGES = REPO_ROOT / "passages"
+
+EVIDENCE_ENUM = {
+    "EMF": "emf", "SPIRITBOX": "spiritbox", "GWB": "gwb",
+    "GLASS": "glass", "TEMPERATURE": "temperature", "UVL": "uvl",
 }
 
-# Per-ghost hunt conditions (GhostController.tw huntCondition). Lambdas over
-# the mc state. Only the ones used by this sim are included.
-# ("sanity_max", T) fires when sanity <= T; ("lust_min", T) when lust >= T.
-GHOST_HUNT_COND: dict[str, tuple[str, int]] = {
-    "Shade":       ("sanity_max", 35),
-    "Spirit":      ("lust_min",   50),
-    "Poltergeist": ("sanity_max", 50),
-    "Phantom":     ("sanity_max", 50),
-    "Goryo":       ("lust_min",   50),
-    "Demon":       ("sanity_max", 70),
-    "Deogen":      ("sanity_max", 50),
-    "Jinn":        ("sanity_max", 50),
-    "Moroi":       ("sanity_max", 50),
-    "Myling":      ("lust_min",   50),
-    "Oni":         ("lust_min",   50),
-    "Mimic":       ("sanity_max", 50),
-    "The Twins":   ("lust_min",   50),
-    "Wraith":      ("lust_min",   50),
-    "Mare":        ("lust_min",   50),
-    "Cthulion":    ("sanity_max", 50),
-    "Banshee":     ("lust_min",   50),
-    "Raiju":       ("sanity_max", 50),
-}
+
+def _read(rel: str) -> str:
+    return (PASSAGES / rel).read_text(encoding="utf-8", errors="replace")
+
+
+def _find_num(pattern: str, text: str, cast=float) -> float:
+    m = re.search(pattern, text)
+    if not m:
+        raise SystemExit(f"parser: couldn't match {pattern!r}")
+    return cast(m.group(1))
+
+
+def _need(m: re.Match | None, what: str) -> re.Match:
+    if m is None:
+        raise SystemExit(f"parser: couldn't find {what}")
+    return m
+
+
+def _parse_ghost_block(block: str) -> dict:
+    name = _need(re.search(r'name:\s*"([^"]+)"', block), "ghost name").group(1)
+    ev_match = _need(re.search(r'evidence:\s*\[([^\]]+)\]', block),
+                     "ghost evidence")
+    evidence = frozenset(
+        EVIDENCE_ENUM[k] for k in re.findall(r'\bE\.([A-Z]+)', ev_match.group(1))
+    )
+    # huntCondition is either `mc.sanity <= N` or `mc.lust >= N`.
+    hc = _need(re.search(
+        r'huntCondition:[^,]*?mc\.(sanity|lust)\s*(<=|>=)\s*(\d+)', block),
+        f"huntCondition for {name}")
+    kind = ("sanity_max" if hc.group(1) == "sanity" else "lust_min")
+    hunt_cond = (kind, int(hc.group(3)))
+    hide = running = None
+    m = re.search(r'hidingSucceeds:\s*(true|false)', block)
+    if m: hide = (m.group(1) == "true")
+    m = re.search(r'runningSucceeds:\s*(true|false)', block)
+    if m: running = (m.group(1) == "true")
+    lo, hi = 1, 5
+    m = re.search(r'sanityEventLossRange:\s*\[(\d+),\s*(\d+)\]', block)
+    if m: lo, hi = int(m.group(1)), int(m.group(2))
+    return {
+        "name": name, "evidence": evidence, "hunt_cond": hunt_cond,
+        "hide": hide, "run": running, "sanity_loss": (lo, hi),
+    }
+
+
+def _load_ghosts() -> list[dict]:
+    src = _read("ghosts/GhostController.tw")
+    gc_start = src.index("var GHOST_CONFIG")
+    # brace-balance the ghost config list; each entry is a `{...}` object
+    list_start = src.index("[", gc_start)
+    i = list_start + 1
+    depth = 0
+    starts: list[int] = []
+    ends: list[int] = []
+    while i < len(src):
+        c = src[i]
+        if c == "[":
+            depth += 1
+        elif c == "]" and depth == 0:
+            break
+        elif c == "]":
+            depth -= 1
+        elif c == "{" and depth == 0:
+            # balance this object literal
+            j = i + 1
+            d = 1
+            while j < len(src) and d > 0:
+                if src[j] == "{": d += 1
+                elif src[j] == "}": d -= 1
+                j += 1
+            starts.append(i)
+            ends.append(j)
+            i = j
+            continue
+        i += 1
+    return [_parse_ghost_block(src[s:e]) for s, e in zip(starts, ends)]
+
+
+def _parse_int_map(text: str, varname: str) -> dict[int, int]:
+    m = re.search(varname + r'\s*=\s*\{([^}]+)\}', text)
+    if not m:
+        raise SystemExit(f"parser: couldn't find {varname}")
+    return {int(k): int(v)
+            for k, v in re.findall(r'(\d+)\s*:\s*(\d+)', m.group(1))}
+
+
+def _parse_snapshot_bonuses(src: str) -> dict[str, dict[str, float]]:
+    """Pull the per-condition snap.X += N lines from setup.HauntConditions
+    .snapshot(). Returns {condition: {field: delta}} for dark / topless /
+    nude / lust_fuel / overcharged."""
+    branches = {
+        "dark":        r'if \(isCurrentRoomDark\(\)\)\s*\{([^}]+)\}',
+        "topless":     r'if \(snap\.clothing === "topless"\)\s*\{([^}]+)\}',
+        "nude":        r'else if \(snap\.clothing === "nude"\)\s*\{([^}]+)\}',
+        "lust_fuel":   r'if \(mc && mc\.lust >= LUST_FUEL_THRESHOLD\)\s*\{([^}]+)\}',
+        "overcharged": r'if \(snap\.overchargedTools\)\s*\{([^}]+)\}',
+    }
+    fields = {
+        "sanity_per_step":  r'snap\.sanityPerStep\s*([+\-])=\s*(\d+)',
+        "lust_per_step":    r'snap\.lustPerStep\s*([+\-])=\s*(\d+)',
+        "tool_chance":      r'snap\.toolChanceBonus\s*([+\-])=\s*(\d+)',
+        "tool_window":      r'snap\.toolWindowBonus\s*([+\-])=\s*(\d+)',
+        "hunt_chance":      r'snap\.huntChanceBonus\s*([+\-])=\s*(\d+)',
+    }
+    out: dict[str, dict[str, float]] = {}
+    for name, block_re in branches.items():
+        m = re.search(block_re, src)
+        if not m:
+            raise SystemExit(f"parser: snapshot branch {name} not found")
+        body = m.group(1)
+        deltas: dict[str, float] = {}
+        for f, pat in fields.items():
+            fm = re.search(pat, body)
+            if fm:
+                sign = 1 if fm.group(1) == "+" else -1
+                deltas[f] = sign * int(fm.group(2))
+        out[name] = deltas
+    return out
+
+
+def _parse_house_rooms(house_id: str) -> list[str]:
+    src = _read("haunted_houses/HauntedHousesController.tw")
+    # Find the HOUSE_CONFIG entry whose `id: '<house_id>'` is present.
+    pat = r"id:\s*'" + re.escape(house_id) + r"'.*?rooms:\s*\[([^\]]+)\]"
+    m = re.search(pat, src, re.DOTALL)
+    if not m:
+        raise SystemExit(f"parser: HOUSE_CONFIG for {house_id!r} not found")
+    return re.findall(r"'([^']+)'", m.group(1))
+
+
+@dataclass
+class GameData:
+    ghosts: dict[str, dict]
+    tier_chance: dict[int, float]            # tier -> per-roll chance (0-1)
+    tool_window: dict[int, int]              # tier -> minutes
+    elm_rooms: list[str]
+    ghost_move_chance: float
+    hunt_base_threshold: int
+    hide_success_base: float                 # 0-1
+    run_success_base: float                  # 0-1
+    energy_per_step: float
+    start_energy: float
+    start_sanity: float
+    start_lust: float
+    lust_fuel_threshold: int
+    dark_bg: int
+    snapshot_bonuses: dict[str, dict[str, float]]
+    ghost_event_chance_per_step: float = 0.05  # not encoded as a single
+                                               # constant in-game; keeps the
+                                               # ArtEvent/EventMC/Freeze
+                                               # activation rate tunable.
+
+
+def load_game_data() -> GameData:
+    story_script = _read("StoryScript.tw")
+    story_init = _read("StoryInit.tw")
+    change_room = _read("haunted_houses/general/ChangeGhostRoom.tw")
+    check_hunt = _read("haunted_houses/hunt/CheckHuntStart.tw")
+    hide_tw = _read("haunted_houses/general/Hide.tw")
+    run_tw = _read("haunted_houses/general/RunFast.tw")
+
+    ghosts = {g["name"]: g for g in _load_ghosts()}
+
+    tier_chance_raw = _parse_int_map(story_script, r"setup\.TIER_CHANCE")
+    tier_chance = {k: v / 100.0 for k, v in tier_chance_raw.items()}
+    tool_window = _parse_int_map(story_script, r"setup\.TOOL_TIME_REMAIN")
+
+    # HauntConditions constants.
+    energy_per_step = _find_num(r"var\s+ENERGY_PER_STEP\s*=\s*([\d.]+)",
+                                story_script)
+    lust_fuel = int(_find_num(r"var\s+LUST_FUEL_THRESHOLD\s*=\s*(\d+)",
+                              story_script))
+    dark_bg = int(_find_num(r"var\s+DARK\s*=\s*(\d+)", story_script))
+    snapshot_bonuses = _parse_snapshot_bonuses(story_script)
+
+    # mc starting stats (StoryInit.tw).
+    start_sanity = _find_num(r"sanity\s*:\s*(\d+)", story_init)
+    start_lust   = _find_num(r"lust\s*:\s*(\d+)",   story_init)
+    start_energy = _find_num(r"energy\s*:\s*(\d+)", story_init)
+
+    # ChangeGhostRoom.tw: Math.random() < 0.35
+    ghost_move_chance = _find_num(r"Math\.random\(\)\s*<\s*([\d.]+)",
+                                   change_room)
+
+    # CheckHuntStart.tw: _huntThreshold to N + setup.HauntConditions...
+    hunt_base_threshold = int(_find_num(r"_huntThreshold\s+to\s+(\d+)",
+                                         check_hunt))
+
+    # Hide.tw: `if _checkH lte 50` -> success (swap: player lucky)
+    hide_pct = _find_num(r"_checkH\s+lte\s+(\d+)", hide_tw) / 100.0
+
+    # RunFast.tw: `if _check lte 30` -> caught; success = 1 - that.
+    run_caught = _find_num(r"_check\s+lte\s+(\d+)", run_tw) / 100.0
+
+    return GameData(
+        ghosts=ghosts,
+        tier_chance=tier_chance,
+        tool_window=tool_window,
+        elm_rooms=_parse_house_rooms("elm"),
+        ghost_move_chance=ghost_move_chance,
+        hunt_base_threshold=hunt_base_threshold,
+        hide_success_base=hide_pct,
+        run_success_base=1.0 - run_caught,
+        energy_per_step=energy_per_step,
+        start_energy=start_energy,
+        start_sanity=start_sanity,
+        start_lust=start_lust,
+        lust_fuel_threshold=lust_fuel,
+        dark_bg=dark_bg,
+        snapshot_bonuses=snapshot_bonuses,
+    )
+
+
+GD = load_game_data()
+
+STEP_MINUTES = 1                 # one nav tick = one in-game minute
+HUNT_EVENT_SANITY_LOSS_DEFAULT = (1, 5)  # Ghost.rollEventSanityLoss default
+
+
+def validate_game_data() -> list[str]:
+    """Assert every piece of game data the simulator depends on is actually
+    present and well-formed. Returns a list of error strings; empty list
+    means the game sources still match the parser's expectations."""
+    errors: list[str] = []
+
+    def require(cond: bool, msg: str) -> None:
+        if not cond:
+            errors.append(msg)
+
+    # Ghosts.
+    expected_ghost_count = 18
+    require(len(GD.ghosts) == expected_ghost_count,
+            f"expected {expected_ghost_count} ghosts, got {len(GD.ghosts)}: "
+            f"{sorted(GD.ghosts)}")
+    valid_evidence = set(EVIDENCE_ENUM.values())
+    for name, g in GD.ghosts.items():
+        require(len(g["evidence"]) == 3,
+                f"ghost {name}: expected 3 evidence types, got "
+                f"{sorted(g['evidence'])}")
+        bad = g["evidence"] - valid_evidence
+        require(not bad, f"ghost {name}: unknown evidence {sorted(bad)}")
+        kind, threshold = g["hunt_cond"]
+        require(kind in ("sanity_max", "lust_min"),
+                f"ghost {name}: bad huntCondition kind {kind!r}")
+        require(0 < threshold <= 100,
+                f"ghost {name}: huntCondition threshold {threshold} "
+                f"out of range")
+        lo, hi = g["sanity_loss"]
+        require(0 < lo <= hi,
+                f"ghost {name}: sanityEventLossRange {g['sanity_loss']} bad")
+
+    # Tier-gated tools.
+    for tier in (3, 4, 5):
+        require(tier in GD.tier_chance,
+                f"TIER_CHANCE missing tier {tier}; got {GD.tier_chance}")
+        require(tier in GD.tool_window,
+                f"TOOL_TIME_REMAIN missing tier {tier}; got {GD.tool_window}")
+    for tier, p in GD.tier_chance.items():
+        require(0 < p <= 1, f"TIER_CHANCE[{tier}]={p} out of (0,1]")
+    for tier, w in GD.tool_window.items():
+        require(w > 0, f"TOOL_TIME_REMAIN[{tier}]={w} not positive")
+
+    # Elm rooms.
+    require(len(GD.elm_rooms) >= 2,
+            f"elm HOUSE_CONFIG.rooms too short: {GD.elm_rooms}")
+    require(len(set(GD.elm_rooms)) == len(GD.elm_rooms),
+            f"elm rooms contain duplicates: {GD.elm_rooms}")
+
+    # Scalar constants.
+    require(0 < GD.ghost_move_chance <= 1,
+            f"ChangeGhostRoom Math.random() threshold "
+            f"{GD.ghost_move_chance} out of (0,1]")
+    require(0 <= GD.hunt_base_threshold <= 100,
+            f"CheckHuntStart base threshold {GD.hunt_base_threshold} bad")
+    require(0 < GD.hide_success_base < 1,
+            f"Hide.tw success base {GD.hide_success_base} bad")
+    require(0 < GD.run_success_base < 1,
+            f"RunFast.tw success base {GD.run_success_base} bad")
+    require(GD.energy_per_step > 0,
+            f"ENERGY_PER_STEP {GD.energy_per_step} not positive")
+    require(GD.start_energy > 0,
+            f"starting energy {GD.start_energy} not positive")
+    require(GD.start_sanity > 0,
+            f"starting sanity {GD.start_sanity} not positive")
+    require(GD.start_lust >= 0,
+            f"starting lust {GD.start_lust} negative")
+    require(GD.lust_fuel_threshold > 0,
+            f"LUST_FUEL_THRESHOLD {GD.lust_fuel_threshold} not positive")
+    require(GD.dark_bg != 1,
+            f"DARK constant collides with LIGHT_ON: {GD.dark_bg}")
+
+    # Snapshot bonuses: every branch we rely on must exist, and at least
+    # one numeric delta within it.
+    for branch in ("dark", "topless", "nude", "lust_fuel", "overcharged"):
+        d = GD.snapshot_bonuses.get(branch)
+        require(bool(d), f"snapshot branch {branch!r} missing from parser")
+        if d:
+            require(any(v != 0 for v in d.values()),
+                    f"snapshot branch {branch!r} has no nonzero deltas: {d}")
+
+    # Spot-check: a run should execute without crashing.
+    try:
+        play_hunt(next(iter(GD.ghosts)), tier=3)
+    except Exception as e:
+        errors.append(f"smoke run raised {type(e).__name__}: {e}")
+
+    return errors
 
 
 def can_hunt(name: str, sanity: float, lust: float) -> bool:
-    kind, threshold = GHOST_HUNT_COND[name]
+    kind, threshold = GD.ghosts[name]["hunt_cond"]
     return sanity <= threshold if kind == "sanity_max" else lust >= threshold
 
-# Ghost override rules for Hide.tw / RunFast.tw. None = default 50/50 roll.
-GHOST_HIDE_SUCCESS = {"Deogen": False, "Jinn": True}
-GHOST_RUN_SUCCESS  = {"Deogen": True,  "Jinn": False}
 
-# setup.TIER_CHANCE (per-roll success for gwb / plasm / spiritbox).
-TIER_CHANCE = {5: 0.15, 4: 0.25, 3: 0.35}
+def ghost_evidence(name: str) -> frozenset[str]:
+    return GD.ghosts[name]["evidence"]
 
-# setup.TOOL_TIME_REMAIN (in-game minutes the emf / uvl window stays open).
-TOOL_WINDOW = {5: 10, 4: 15, 3: 20}
 
-# HauntConditions constants.
-ENERGY_PER_STEP = 0.25
-START_ENERGY = 10.0
-START_SANITY = 100
-START_LUST = 0
-STEP_MINUTES = 1
-GHOST_MOVE_CHANCE = 0.35
-GHOST_EVENT_CHANCE_PER_STEP = 0.05  # approximates ArtEvent* / EventMC etc.
-HUNT_BASE_THRESHOLD = 6             # CheckHuntStart.tw: 6 + huntChanceBonus
-HUNT_EVENT_SANITY_LOSS = (1, 5)     # Ghost.rollEventSanityLoss default
-HIDE_SUCCESS_BASE = 0.50            # Hide.tw threshold (checkH <= 50)
-RUN_SUCCESS_BASE  = 0.70            # RunFast.tw threshold (check > 30)
-
-# Dark = room.background === 2 (lights off).
-LIGHT_ON, LIGHT_OFF = 1, 2
+LIGHT_ON = 1
+LIGHT_OFF = GD.dark_bg
 
 
 @dataclass
 class Mc:
-    sanity: float = START_SANITY
-    lust: float = START_LUST
-    energy: float = START_ENERGY
+    sanity: float = field(default_factory=lambda: GD.start_sanity)
+    lust: float = field(default_factory=lambda: GD.start_lust)
+    energy: float = field(default_factory=lambda: GD.start_energy)
 
 
 @dataclass
 class Hunt:
     ghost_name: str
     tier: int = 3
-    rooms: list[str] = field(default_factory=lambda: list(ELM_ROOMS))
+    rooms: list[str] = field(default_factory=lambda: list(GD.elm_rooms))
     mc: Mc = field(default_factory=Mc)
     minutes: int = 0
     ghost_room: str = ""
@@ -174,7 +429,7 @@ class Hunt:
     # --- snapshots / state queries ------------------------------------
     @property
     def ghost_evidence(self) -> frozenset[str]:
-        return GHOST_EVIDENCE[self.ghost_name]
+        return ghost_evidence(self.ghost_name)
 
     @property
     def clothing(self) -> str:
@@ -191,32 +446,40 @@ class Hunt:
         return self.lights.get(self.current_room, LIGHT_ON) == LIGHT_OFF
 
     def snapshot(self) -> dict:
-        """Mirror of setup.HauntConditions.snapshot()."""
-        snap = dict(sanity_per_step=0, lust_per_step=0,
-                    tool_chance_bonus=0.0, tool_window_bonus=0,
-                    hunt_chance_bonus=0)
+        """Mirror of setup.HauntConditions.snapshot() - pulls per-branch
+        deltas from GD.snapshot_bonuses, which is parsed from StoryScript.tw."""
+        snap = dict(sanity_per_step=0.0, lust_per_step=0.0,
+                    tool_chance_bonus=0.0, tool_window_bonus=0.0,
+                    hunt_chance_bonus=0.0)
+        active: list[str] = []
         if self.dark:
-            snap["sanity_per_step"] -= 1
-            snap["tool_chance_bonus"] += 0.10
-            snap["tool_window_bonus"] += 5
-            snap["hunt_chance_bonus"] += 6
+            active.append("dark")
         c = self.clothing
         if c == "topless":
-            snap["tool_chance_bonus"] += 0.05
-            snap["lust_per_step"]     += 1
-            snap["hunt_chance_bonus"] += 3
+            active.append("topless")
         elif c == "nude":
-            snap["tool_chance_bonus"] += 0.10
-            snap["lust_per_step"]     += 2
-            snap["hunt_chance_bonus"] += 5
-        if self.mc.lust >= 50:
-            snap["tool_chance_bonus"] += 0.05
-            snap["hunt_chance_bonus"] += 3
+            active.append("nude")
+        if self.mc.lust >= GD.lust_fuel_threshold:
+            active.append("lust_fuel")
         if self.overcharged:
-            snap["tool_chance_bonus"] += 0.10
-            snap["tool_window_bonus"] += 5
-            snap["hunt_chance_bonus"] += 5
-            snap["sanity_per_step"]   -= 1
+            active.append("overcharged")
+        for branch in active:
+            for k, v in GD.snapshot_bonuses[branch].items():
+                # tool_chance / hunt_chance are percent points in the
+                # game; the tier-chance table is decimal (0-1). Scale the
+                # tool-chance bonus into 0-1, leave hunt-chance as
+                # percent points (CheckHuntStart.tw compares vs a 0-100
+                # roll).
+                if k == "tool_chance":
+                    snap["tool_chance_bonus"] += v / 100.0
+                elif k == "hunt_chance":
+                    snap["hunt_chance_bonus"] += v
+                elif k == "tool_window":
+                    snap["tool_window_bonus"] += v
+                elif k == "sanity_per_step":
+                    snap["sanity_per_step"] += v
+                elif k == "lust_per_step":
+                    snap["lust_per_step"] += v
         return snap
 
     # --- time / ghost bookkeeping -------------------------------------
@@ -227,7 +490,7 @@ class Hunt:
     def _maybe_move_ghost(self) -> None:
         i = self._interval()
         if i != self.last_move_interval:
-            if random.random() < GHOST_MOVE_CHANCE:
+            if random.random() < GD.ghost_move_chance:
                 self.ghost_room = random.choice(self.rooms)
             self.last_move_interval = i
 
@@ -242,26 +505,27 @@ class Hunt:
         else None."""
         self.current_room = room
         self.minutes += STEP_MINUTES
-        self.mc.energy -= ENERGY_PER_STEP
+        self.mc.energy -= GD.energy_per_step
         self._maybe_move_ghost()
 
         # Per-step tick effects (HauntConditions.applyTickEffects).
         snap = self.snapshot()
-        self.mc.sanity = clamp(self.mc.sanity + snap["sanity_per_step"], 1, START_SANITY)
+        self.mc.sanity = clamp(self.mc.sanity + snap["sanity_per_step"],
+                               1, GD.start_sanity)
         self.mc.lust   = clamp(self.mc.lust + snap["lust_per_step"], 0, 100)
         # Sanity never hits 0 via natural drain (min clamp 1); the hunt-over
         # -sanity exit comes from GhostHuntEvent's rollEventSanityLoss. We
         # still surface sanity_zero if some future sink drives it below 1.
 
         # Ghost event (activates tools).
-        if random.random() < GHOST_EVENT_CHANCE_PER_STEP:
+        if random.random() < GD.ghost_event_chance_per_step:
             self._activate("uvl")
             self._activate("emf")
 
         # Random ghost-hunt roll (CheckHuntStart.tw).
         if not self.hunt_active_flag and can_hunt(
                 self.ghost_name, self.mc.sanity, self.mc.lust):
-            threshold = HUNT_BASE_THRESHOLD + snap["hunt_chance_bonus"]
+            threshold = GD.hunt_base_threshold + snap["hunt_chance_bonus"]
             if random.randint(0, 100) <= threshold:
                 reason = self._resolve_hunt_event()
                 if reason:
@@ -272,20 +536,22 @@ class Hunt:
         """GhostHuntEvent.tw: AI hides. Returns exit reason if caught,
         else None (hunt passed, event marker set)."""
         self.hunt_active_flag = True
-        # Sanity event loss on hunt start.
-        lo, hi = HUNT_EVENT_SANITY_LOSS
+        # Sanity event loss on hunt start - ghost-specific range when set,
+        # else the Ghost.rollEventSanityLoss default.
+        lo, hi = GD.ghosts[self.ghost_name].get(
+            "sanity_loss", HUNT_EVENT_SANITY_LOSS_DEFAULT)
         self.mc.sanity -= random.randint(lo, hi)
         if self.mc.sanity < 1:
             self.mc.sanity = 0
             return "sanity_zero"
         # Hide (AI's default). Ghost override beats the roll.
-        override = GHOST_HIDE_SUCCESS.get(self.ghost_name)
+        override = GD.ghosts[self.ghost_name].get("hide")
         if override is True:
             survived = True
         elif override is False:
             survived = False
         else:
-            survived = random.random() < HIDE_SUCCESS_BASE
+            survived = random.random() < GD.hide_success_base
         if not survived:
             return "caught_in_hunt"
         # Survived - ghost event bumps both timed tools (like FreezeHunt).
@@ -300,8 +566,8 @@ class Hunt:
 
     # --- tool rolls ----------------------------------------------------
     def _activate(self, tool: str) -> None:
-        window = TOOL_WINDOW[self.tier] + self.snapshot()["tool_window_bonus"]
-        until = self.minutes + window
+        window = GD.tool_window[self.tier] + self.snapshot()["tool_window_bonus"]
+        until = self.minutes + int(window)
         if tool == "emf":
             self.emf_until = max(self.emf_until, until)
         else:
@@ -309,7 +575,7 @@ class Hunt:
 
     def _roll_tier(self) -> bool:
         bonus = self.snapshot()["tool_chance_bonus"]
-        return random.random() < TIER_CHANCE[self.tier] + bonus
+        return random.random() < GD.tier_chance[self.tier] + bonus
 
     def temperature_scan(self) -> int:
         base = random.randint(13, 16)
@@ -473,15 +739,16 @@ class Result:
 
 
 def simulate(ghost_name: str, trials: int, tier: int) -> Result:
-    if ghost_name not in GHOST_EVIDENCE:
+    if ghost_name not in GD.ghosts:
         raise SystemExit(f"Unknown ghost: {ghost_name!r}. "
-                         f"Choose from {sorted(GHOST_EVIDENCE)} or 'all'.")
-    if tier not in TIER_CHANCE:
-        raise SystemExit(f"Unknown tier: {tier}. Choose 3, 4, or 5.")
+                         f"Choose from {sorted(GD.ghosts)} or 'all'.")
+    if tier not in GD.tier_chance:
+        raise SystemExit(f"Unknown tier: {tier}. "
+                         f"Choose from {sorted(GD.tier_chance)}.")
 
+    target = ghost_evidence(ghost_name)
     wins = 0
-    evidence_counts = {e: 0 for e in {"emf", "gwb", "glass",
-                                       "spiritbox", "temperature", "uvl"}}
+    evidence_counts = {e: 0 for e in EVIDENCE_ENUM.values()}
     count_by_found = [0] * 4
     fail_reasons: dict[str, int] = {
         "energy": 0, "sanity_zero": 0, "caught_in_hunt": 0, "search_timeout": 0,
@@ -494,18 +761,18 @@ def simulate(ghost_name: str, trials: int, tier: int) -> Result:
             wins += 1
         else:
             fail_reasons[reason] = fail_reasons.get(reason, 0) + 1
-            missing = tuple(sorted(GHOST_EVIDENCE[ghost_name] - found))
+            missing = tuple(sorted(target - found))
             missed_evidence[missing] = missed_evidence.get(missing, 0) + 1
         for e in found:
-            evidence_counts[e] += 1
-        count_by_found[min(len(found & GHOST_EVIDENCE[ghost_name]), 3)] += 1
+            evidence_counts[e] = evidence_counts.get(e, 0) + 1
+        count_by_found[min(len(found & target), 3)] += 1
 
     return Result(ghost_name, trials, tier, wins, evidence_counts,
                   count_by_found, fail_reasons, missed_evidence)
 
 
 def print_detailed(r: Result) -> None:
-    target = sorted(GHOST_EVIDENCE[r.ghost])
+    target = sorted(ghost_evidence(r.ghost))
     losses = r.trials - r.wins
     print(f"Elm Street AI hunt - {r.trials} runs vs {r.ghost} (tier {r.tier})")
     print(f"  target evidence: {target}")
@@ -590,16 +857,29 @@ def print_summary(results: list[Result]) -> None:
 
 
 def main() -> None:
-    arg = sys.argv[1] if len(sys.argv) > 1 else "all"
+    args = sys.argv[1:]
+    if args and args[0] == "--validate-data":
+        errors = validate_game_data()
+        if errors:
+            print("sim_ai_hunt.py: game-data validation FAILED "
+                  f"({len(errors)} issue(s)):", file=sys.stderr)
+            for e in errors:
+                print(f"  - {e}", file=sys.stderr)
+            sys.exit(1)
+        print(f"sim_ai_hunt.py: game-data validation OK "
+              f"({len(GD.ghosts)} ghosts, {len(GD.elm_rooms)} elm rooms, "
+              f"{len(GD.tier_chance)} tool tiers).")
+        return
+    arg = args[0] if args else "all"
     if arg == "all":
-        trials = int(sys.argv[2]) if len(sys.argv) > 2 else 5000
-        tier = int(sys.argv[3]) if len(sys.argv) > 3 else 3
+        trials = int(args[1]) if len(args) > 1 else 5000
+        tier = int(args[2]) if len(args) > 2 else 3
         results = [simulate(name, trials, tier)
-                   for name in GHOST_EVIDENCE]
+                   for name in GD.ghosts]
         print_summary(results)
     else:
-        trials = int(sys.argv[2]) if len(sys.argv) > 2 else 10000
-        tier = int(sys.argv[3]) if len(sys.argv) > 3 else 3
+        trials = int(args[1]) if len(args) > 1 else 10000
+        tier = int(args[2]) if len(args) > 2 else 3
         print_detailed(simulate(arg, trials, tier))
 
 

--- a/sim_ai_hunt.py
+++ b/sim_ai_hunt.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 """
-Simplistic AI that plays through an Elm Street hunt against a fixed ghost type.
+Simplistic AI that plays through a haunted-house contract against every
+ghost type in every house (Owaissa / Elm / Enigma / Ironclad), using data
+parsed from the game's own .tw sources at startup.
 
 Models the core hunt loop from Ghost in M'Sheet:
 
-  - Ghost picks a favorite room from Elm's 9-room list at contract start
-    and can switch rooms every 20 in-game minutes with 35% probability
+  - Ghost picks a favorite room from the house's room list at contract
+    start and can switch rooms every 20 in-game minutes with 35% chance
     (ChangeGhostRoom.tw / HauntedHouses.rollStartingRoom).
   - Navigating between rooms costs 0.25 energy per step (HauntConditions
     ENERGY_PER_STEP); the contract ends when energy bottoms out.
@@ -40,8 +42,12 @@ Simple AI patterns:
   3) "Respond to hunt" - on a hunt event, hide (ghost overrides aside).
 
 Usage:
-    python3 sim_ai_hunt.py                   # Phantom, 10000 runs, tier 3
-    python3 sim_ai_hunt.py Goryo 50000 4     # different ghost / trials / tier
+    python3 sim_ai_hunt.py                 # every house x every ghost
+    python3 sim_ai_hunt.py elm             # all ghosts in one house
+    python3 sim_ai_hunt.py elm Phantom     # detailed single (house, ghost)
+    python3 sim_ai_hunt.py Phantom         # one ghost across all houses
+    python3 sim_ai_hunt.py --validate-data # check parser still matches game
+Trailing positional args are [trials] [tier] on each form.
 """
 
 from __future__ import annotations
@@ -188,14 +194,15 @@ def _parse_snapshot_bonuses(src: str) -> dict[str, dict[str, float]]:
     return out
 
 
-def _parse_house_rooms(house_id: str) -> list[str]:
+def _parse_houses() -> dict[str, list[str]]:
+    """Pull every HOUSE_CONFIG entry's id + rooms out of
+    HauntedHousesController.tw. Returns {house_id: [room_var_name, ...]}."""
     src = _read("haunted_houses/HauntedHousesController.tw")
-    # Find the HOUSE_CONFIG entry whose `id: '<house_id>'` is present.
-    pat = r"id:\s*'" + re.escape(house_id) + r"'.*?rooms:\s*\[([^\]]+)\]"
-    m = re.search(pat, src, re.DOTALL)
-    if not m:
-        raise SystemExit(f"parser: HOUSE_CONFIG for {house_id!r} not found")
-    return re.findall(r"'([^']+)'", m.group(1))
+    out: dict[str, list[str]] = {}
+    for m in re.finditer(
+            r"id:\s*'([^']+)'[^{}]*?rooms:\s*\[([^\]]+)\]", src, re.DOTALL):
+        out[m.group(1)] = re.findall(r"'([^']+)'", m.group(2))
+    return out
 
 
 @dataclass
@@ -203,7 +210,7 @@ class GameData:
     ghosts: dict[str, dict]
     tier_chance: dict[int, float]            # tier -> per-roll chance (0-1)
     tool_window: dict[int, int]              # tier -> minutes
-    elm_rooms: list[str]
+    houses: dict[str, list[str]]             # house id -> room names
     ghost_move_chance: float
     hunt_base_threshold: int
     hide_success_base: float                 # 0-1
@@ -266,7 +273,7 @@ def load_game_data() -> GameData:
         ghosts=ghosts,
         tier_chance=tier_chance,
         tool_window=tool_window,
-        elm_rooms=_parse_house_rooms("elm"),
+        houses=_parse_houses(),
         ghost_move_chance=ghost_move_chance,
         hunt_base_threshold=hunt_base_threshold,
         hide_success_base=hide_pct,
@@ -330,11 +337,15 @@ def validate_game_data() -> list[str]:
     for tier, w in GD.tool_window.items():
         require(w > 0, f"TOOL_TIME_REMAIN[{tier}]={w} not positive")
 
-    # Elm rooms.
-    require(len(GD.elm_rooms) >= 2,
-            f"elm HOUSE_CONFIG.rooms too short: {GD.elm_rooms}")
-    require(len(set(GD.elm_rooms)) == len(GD.elm_rooms),
-            f"elm rooms contain duplicates: {GD.elm_rooms}")
+    # Houses.
+    expected_houses = {"elm", "owaissa", "enigma", "ironclad"}
+    missing = expected_houses - set(GD.houses)
+    require(not missing, f"HOUSE_CONFIG missing houses: {sorted(missing)}")
+    for house, rooms in GD.houses.items():
+        require(len(rooms) >= 2,
+                f"house {house!r} rooms too short: {rooms}")
+        require(len(set(rooms)) == len(rooms),
+                f"house {house!r} rooms contain duplicates: {rooms}")
 
     # Scalar constants.
     require(0 < GD.ghost_move_chance <= 1,
@@ -368,11 +379,14 @@ def validate_game_data() -> list[str]:
             require(any(v != 0 for v in d.values()),
                     f"snapshot branch {branch!r} has no nonzero deltas: {d}")
 
-    # Spot-check: a run should execute without crashing.
-    try:
-        play_hunt(next(iter(GD.ghosts)), tier=3)
-    except Exception as e:
-        errors.append(f"smoke run raised {type(e).__name__}: {e}")
+    # Spot-check: a run should execute without crashing in each house.
+    ghost = next(iter(GD.ghosts))
+    for house in GD.houses:
+        try:
+            play_hunt(ghost, house=house, tier=3)
+        except Exception as e:
+            errors.append(
+                f"smoke run in {house} raised {type(e).__name__}: {e}")
 
     return errors
 
@@ -400,8 +414,9 @@ class Mc:
 @dataclass
 class Hunt:
     ghost_name: str
+    house: str = "elm"
     tier: int = 3
-    rooms: list[str] = field(default_factory=lambda: list(GD.elm_rooms))
+    rooms: list[str] = field(default_factory=list)
     mc: Mc = field(default_factory=Mc)
     minutes: int = 0
     ghost_room: str = ""
@@ -421,6 +436,11 @@ class Hunt:
     exit_reason: str = ""
 
     def __post_init__(self) -> None:
+        if not self.rooms:
+            if self.house not in GD.houses:
+                raise SystemExit(f"Unknown house: {self.house!r}. "
+                                 f"Choose from {sorted(GD.houses)}.")
+            self.rooms = list(GD.houses[self.house])
         self.ghost_room = random.choice(self.rooms)
         self.current_room = random.choice(self.rooms)
         self.last_move_interval = self._interval()
@@ -696,11 +716,12 @@ def pattern_scan_for_evidence(hunt: Hunt, suspected: str, rounds: int = 6
     return hunt.found >= hunt.ghost_evidence, None
 
 
-def play_hunt(ghost_name: str, tier: int = 3) -> tuple[bool, set[str], str]:
+def play_hunt(ghost_name: str, house: str = "elm", tier: int = 3
+              ) -> tuple[bool, set[str], str]:
     """Run one contract with the simple AI. Returns
     (identified, evidence_seen, exit_reason). exit_reason in
     {identified, energy, sanity_zero, caught_in_hunt, search_timeout}."""
-    hunt = Hunt(ghost_name=ghost_name, tier=tier)
+    hunt = Hunt(ghost_name=ghost_name, house=house, tier=tier)
 
     while not hunt.out_of_energy() and hunt.found < hunt.ghost_evidence:
         suspected, reason = pattern_find_ghost_room(hunt)
@@ -729,6 +750,7 @@ def play_hunt(ghost_name: str, tier: int = 3) -> tuple[bool, set[str], str]:
 @dataclass
 class Result:
     ghost: str
+    house: str
     trials: int
     tier: int
     wins: int
@@ -738,10 +760,13 @@ class Result:
     missed_evidence: dict[tuple[str, ...], int]
 
 
-def simulate(ghost_name: str, trials: int, tier: int) -> Result:
+def simulate(ghost_name: str, house: str, trials: int, tier: int) -> Result:
     if ghost_name not in GD.ghosts:
         raise SystemExit(f"Unknown ghost: {ghost_name!r}. "
                          f"Choose from {sorted(GD.ghosts)} or 'all'.")
+    if house not in GD.houses:
+        raise SystemExit(f"Unknown house: {house!r}. "
+                         f"Choose from {sorted(GD.houses)} or 'all'.")
     if tier not in GD.tier_chance:
         raise SystemExit(f"Unknown tier: {tier}. "
                          f"Choose from {sorted(GD.tier_chance)}.")
@@ -756,7 +781,7 @@ def simulate(ghost_name: str, trials: int, tier: int) -> Result:
     missed_evidence: dict[tuple[str, ...], int] = {}
 
     for _ in range(trials):
-        ok, found, reason = play_hunt(ghost_name, tier=tier)
+        ok, found, reason = play_hunt(ghost_name, house=house, tier=tier)
         if ok:
             wins += 1
         else:
@@ -767,14 +792,15 @@ def simulate(ghost_name: str, trials: int, tier: int) -> Result:
             evidence_counts[e] = evidence_counts.get(e, 0) + 1
         count_by_found[min(len(found & target), 3)] += 1
 
-    return Result(ghost_name, trials, tier, wins, evidence_counts,
+    return Result(ghost_name, house, trials, tier, wins, evidence_counts,
                   count_by_found, fail_reasons, missed_evidence)
 
 
 def print_detailed(r: Result) -> None:
     target = sorted(ghost_evidence(r.ghost))
     losses = r.trials - r.wins
-    print(f"Elm Street AI hunt - {r.trials} runs vs {r.ghost} (tier {r.tier})")
+    print(f"{r.house} AI hunt - {r.trials} runs vs {r.ghost} "
+          f"(tier {r.tier}, {len(GD.houses[r.house])} rooms)")
     print(f"  target evidence: {target}")
     print(f"  identified correctly: {r.wins}/{r.trials} "
           f"({100 * r.wins / r.trials:.2f}%)")
@@ -809,51 +835,89 @@ def _top_reason(reasons: dict[str, int]) -> tuple[str, int]:
     return max(nonzero, key=lambda kv: kv[1])
 
 
-def print_summary(results: list[Result]) -> None:
-    trials = results[0].trials
-    tier = results[0].tier
-    total_runs = sum(r.trials for r in results)
-    total_wins = sum(r.wins for r in results)
-    overall_reasons: dict[str, int] = {}
+def _row_for(r: Result) -> tuple[float, str, str]:
+    """Per-result summary row: (success_pct, ghost_label, failure_blurb)."""
+    rate = 100 * r.wins / r.trials
+    fails = r.trials - r.wins
+    if not fails:
+        return (rate, r.ghost, "-")
+    reason, count = _top_reason(r.fail_reasons)
+    miss, miss_count = max(r.missed_evidence.items(), key=lambda kv: kv[1])
+    miss_label = "+".join(miss) if miss else "none"
+    return (rate, r.ghost,
+            f"{reason} {count}/{fails} (miss {miss_label} {miss_count})")
+
+
+def print_house_summary(results: list[Result], keep: int = 2) -> None:
+    """Compact per-house summary: the `keep` worst and best ghosts only."""
+    assert results, "print_house_summary called with no results"
+    house = results[0].house
+    ordered = sorted(results, key=lambda x: x.wins / x.trials)
+    trials_total = sum(r.trials for r in results)
+    wins_total = sum(r.wins for r in results)
+    fails = trials_total - wins_total
+    house_reasons: dict[str, int] = {}
     for r in results:
+        for k, v in r.fail_reasons.items():
+            house_reasons[k] = house_reasons.get(k, 0) + v
+
+    header = (f"{house} ({len(GD.houses[house])} rooms) - "
+              f"{100 * wins_total / trials_total:.2f}% overall")
+    if fails:
+        reason, count = _top_reason(house_reasons)
+        header += f" - top fail {reason} {count}/{fails}"
+    print(header)
+
+    # 2 worst, 2 best. Collapse if total ghosts <= 2*keep (would double-print).
+    if len(ordered) <= keep * 2:
+        shown = [("", r) for r in ordered]
+    else:
+        shown = ([("worst", r) for r in ordered[:keep]]
+                 + [("best", r) for r in ordered[-keep:][::-1]])
+    for label, r in shown:
+        rate, name, blurb = _row_for(r)
+        prefix = f"  [{label}]" if label else "  "
+        print(f"{prefix:<9} {name:<13} {rate:>7.2f}%   {blurb}")
+
+
+def print_overall(all_results: list[Result]) -> None:
+    """Footer across every (house, ghost) pair."""
+    total_runs = sum(r.trials for r in all_results)
+    total_wins = sum(r.wins for r in all_results)
+    overall_reasons: dict[str, int] = {}
+    for r in all_results:
         for k, v in r.fail_reasons.items():
             overall_reasons[k] = overall_reasons.get(k, 0) + v
 
-    print(f"Elm Street AI hunt - {trials} runs per ghost, tier {tier}, "
-          f"{len(results)} ghosts ({total_runs} runs total)")
     print()
-    header = f"  {'ghost':<13} {'success':>8}   {'top failure':<24}"
-    print(header)
-    print(f"  {'-' * 13} {'-' * 8}   {'-' * 24}")
-    # Worst ghosts first so the interesting ones are easy to spot.
-    for r in sorted(results, key=lambda x: x.wins / x.trials):
-        rate = 100 * r.wins / r.trials
-        fails = r.trials - r.wins
-        if fails:
-            reason, count = _top_reason(r.fail_reasons)
-            miss, miss_count = max(r.missed_evidence.items(),
-                                    key=lambda kv: kv[1])
-            miss_label = "+".join(miss) if miss else "none"
-            top = (f"{reason} {count}/{fails}"
-                   f" (miss {miss_label} {miss_count})")
-        else:
-            top = "-"
-        print(f"  {r.ghost:<13} {rate:>7.2f}%   {top:<24}")
-
-    print()
-    overall_rate = 100 * total_wins / total_runs
-    print(f"  overall success: {total_wins}/{total_runs} ({overall_rate:.2f}%)")
+    print(f"overall success: {total_wins}/{total_runs} "
+          f"({100 * total_wins / total_runs:.2f}%)")
     total_fails = total_runs - total_wins
     if total_fails:
-        top_reason, top_count = _top_reason(overall_reasons)
-        print(f"  overall top failure: {top_reason} "
-              f"({top_count}/{total_fails} fails, "
-              f"{100 * top_count / total_runs:.2f}% of runs)")
+        top_r, top_c = _top_reason(overall_reasons)
+        print(f"overall top failure: {top_r} ({top_c}/{total_fails} fails, "
+              f"{100 * top_c / total_runs:.2f}% of runs)")
         ordered = sorted(overall_reasons.items(), key=lambda kv: -kv[1])
         breakdown = ", ".join(f"{k}={v}" for k, v in ordered if v)
-        print(f"  failure breakdown: {breakdown}")
+        print(f"failure breakdown: {breakdown}")
     else:
-        print("  overall top failure: none")
+        print("overall top failure: none")
+
+
+def run_all_houses(trials: int, tier: int) -> None:
+    total_ghosts = len(GD.ghosts)
+    total_runs = total_ghosts * len(GD.houses) * trials
+    print(f"AI hunt - {trials} runs per (house, ghost), tier {tier}, "
+          f"{len(GD.houses)} houses x {total_ghosts} ghosts "
+          f"({total_runs} runs total)")
+    all_results: list[Result] = []
+    for house in GD.houses:
+        print()
+        house_results = [simulate(name, house, trials, tier)
+                         for name in GD.ghosts]
+        all_results.extend(house_results)
+        print_house_summary(house_results, keep=2)
+    print_overall(all_results)
 
 
 def main() -> None:
@@ -866,21 +930,64 @@ def main() -> None:
             for e in errors:
                 print(f"  - {e}", file=sys.stderr)
             sys.exit(1)
+        total_rooms = sum(len(v) for v in GD.houses.values())
         print(f"sim_ai_hunt.py: game-data validation OK "
-              f"({len(GD.ghosts)} ghosts, {len(GD.elm_rooms)} elm rooms, "
-              f"{len(GD.tier_chance)} tool tiers).")
+              f"({len(GD.ghosts)} ghosts, {len(GD.houses)} houses, "
+              f"{total_rooms} rooms, {len(GD.tier_chance)} tool tiers).")
         return
+
     arg = args[0] if args else "all"
     if arg == "all":
+        trials = int(args[1]) if len(args) > 1 else 3000
+        tier = int(args[2]) if len(args) > 2 else 3
+        run_all_houses(trials, tier)
+    elif arg in GD.houses:
+        # <house> [<ghost>] [trials] [tier] -- one house, either all ghosts
+        # or a specific ghost.
+        house = arg
+        if len(args) > 1 and args[1] in GD.ghosts:
+            ghost = args[1]
+            trials = int(args[2]) if len(args) > 2 else 10000
+            tier = int(args[3]) if len(args) > 3 else 3
+            print_detailed(simulate(ghost, house, trials, tier))
+        else:
+            trials = int(args[1]) if len(args) > 1 else 5000
+            tier = int(args[2]) if len(args) > 2 else 3
+            results = [simulate(name, house, trials, tier)
+                       for name in GD.ghosts]
+            print(f"AI hunt - {trials} runs per ghost in {house} (tier {tier})")
+            print()
+            # Full per-ghost listing when explicitly scoped to one house.
+            for r in sorted(results, key=lambda x: x.wins / x.trials):
+                rate, name, blurb = _row_for(r)
+                print(f"  {name:<13} {rate:>7.2f}%   {blurb}")
+            print_overall(results)
+    elif arg in GD.ghosts:
+        # <ghost>: run it in every house for comparison.
+        ghost = arg
         trials = int(args[1]) if len(args) > 1 else 5000
         tier = int(args[2]) if len(args) > 2 else 3
-        results = [simulate(name, trials, tier)
-                   for name in GD.ghosts]
-        print_summary(results)
+        print(f"AI hunt - {trials} runs vs {ghost} across "
+              f"{len(GD.houses)} houses (tier {tier})")
+        print()
+        results = [simulate(ghost, house, trials, tier)
+                   for house in GD.houses]
+        for r in sorted(results, key=lambda x: x.wins / x.trials):
+            rate = 100 * r.wins / r.trials
+            fails = r.trials - r.wins
+            if fails:
+                reason, count = _top_reason(r.fail_reasons)
+                blurb = f"{reason} {count}/{fails}"
+            else:
+                blurb = "-"
+            print(f"  {r.house:<10} ({len(GD.houses[r.house]):>2} rooms)"
+                  f"  {rate:>7.2f}%   {blurb}")
+        print_overall(results)
     else:
-        trials = int(args[1]) if len(args) > 1 else 10000
-        tier = int(args[2]) if len(args) > 2 else 3
-        print_detailed(simulate(arg, trials, tier))
+        raise SystemExit(
+            f"Unknown arg: {arg!r}. Use 'all', a house id "
+            f"({sorted(GD.houses)}), or a ghost name "
+            f"({sorted(GD.ghosts)}).")
 
 
 if __name__ == "__main__":

--- a/sim_ai_hunt.py
+++ b/sim_ai_hunt.py
@@ -1,0 +1,607 @@
+#!/usr/bin/env python3
+"""
+Simplistic AI that plays through an Elm Street hunt against a fixed ghost type.
+
+Models the core hunt loop from Ghost in M'Sheet:
+
+  - Ghost picks a favorite room from Elm's 9-room list at contract start
+    and can switch rooms every 20 in-game minutes with 35% probability
+    (ChangeGhostRoom.tw / HauntedHouses.rollStartingRoom).
+  - Navigating between rooms costs 0.25 energy per step (HauntConditions
+    ENERGY_PER_STEP); the contract ends when energy bottoms out.
+  - Evidence detection uses the same tier-based chance table as the game:
+      * gwb / plasm / spiritbox:  tier 3 -> 35%, tier 4 -> 25%, tier 5 -> 15%
+        (setup.TIER_CHANCE in StoryScript.tw)
+      * emf / uvl:                timed tools - require activation; read
+        positive while their window is open AND the ghost has that evidence
+      * temperature:              passive; fires when in the ghost's room and
+        the ghost has temperature evidence
+
+  - Haunt conditions (HauntConditions.snapshot) layered on top of each tick:
+      * lights off (dark):   sanity -1/step, tool chance +10%, hunt +6%
+      * topless:             lust +1/step, tool +5%, hunt +3%
+      * nude:                lust +2/step, tool +10%, hunt +5%
+      * lust >= 50:          tool +5%, hunt +3%
+      * overcharged tools:   tool +10%, tool window +5, hunt +5%, sanity -1/step
+  - Ghost hunts (CheckHuntStart.tw): each nav tick rolls random(0,100) <=
+    6 + huntChanceBonus. If the ghost's canHunt(mc) gate is also satisfied,
+    a hunt fires. The AI hides; ghost-specific override rules (Deogen,
+    Jinn) apply via runningSucceeds / hidingSucceeds.
+  - Exit reasons tracked: identified, energy, sanity_zero (HuntOverSanity),
+    caught_in_hunt (HuntEnd), search_timeout.
+
+Simple AI patterns:
+  1) "Find ghost's favorite room" - walk rooms with lights ON (safe),
+     take temperature readings; elevated reading (>= 18) means ghost room.
+  2) "Scan for evidence in the ghost's room" - turn lights off for the
+     tool bonus, scan every tool each round, revert lights if sanity gets
+     dangerous. If evidence is still incomplete and the ghost relocates,
+     drop back to pattern 1.
+  3) "Respond to hunt" - on a hunt event, hide (ghost overrides aside).
+
+Usage:
+    python3 sim_ai_hunt.py                   # Phantom, 10000 runs, tier 3
+    python3 sim_ai_hunt.py Goryo 50000 4     # different ghost / trials / tier
+"""
+
+from __future__ import annotations
+
+import random
+import sys
+from dataclasses import dataclass, field
+
+
+ELM_ROOMS = [
+    "kitchen", "bathroom", "bedroom", "nursery", "hallway",
+    "hallwayUpstairs", "bedroomTwo", "bathroomTwo", "basement",
+]
+
+# Evidence triples from GhostController.tw. Mimic's "extra glass" bonus is
+# ignored here (the simulation identifies by the canonical triple).
+GHOST_EVIDENCE: dict[str, frozenset[str]] = {
+    "Shade":       frozenset({"emf", "gwb", "temperature"}),
+    "Spirit":      frozenset({"emf", "spiritbox", "gwb"}),
+    "Poltergeist": frozenset({"spiritbox", "gwb", "uvl"}),
+    "Phantom":     frozenset({"glass", "uvl", "spiritbox"}),
+    "Goryo":       frozenset({"glass", "uvl", "emf"}),
+    "Demon":       frozenset({"gwb", "uvl", "temperature"}),
+    "Deogen":      frozenset({"glass", "gwb", "spiritbox"}),
+    "Jinn":        frozenset({"emf", "uvl", "temperature"}),
+    "Moroi":       frozenset({"gwb", "temperature", "spiritbox"}),
+    "Myling":      frozenset({"gwb", "emf", "uvl"}),
+    "Oni":         frozenset({"glass", "emf", "temperature"}),
+    "Mimic":       frozenset({"uvl", "temperature", "spiritbox"}),
+    "The Twins":   frozenset({"emf", "temperature", "spiritbox"}),
+    "Wraith":      frozenset({"glass", "emf", "spiritbox"}),
+    "Mare":        frozenset({"glass", "gwb", "temperature"}),
+    "Cthulion":    frozenset({"spiritbox", "glass", "temperature"}),
+    "Banshee":     frozenset({"glass", "gwb", "uvl"}),
+    "Raiju":       frozenset({"emf", "spiritbox", "uvl"}),
+}
+
+# Per-ghost hunt conditions (GhostController.tw huntCondition). Lambdas over
+# the mc state. Only the ones used by this sim are included.
+# ("sanity_max", T) fires when sanity <= T; ("lust_min", T) when lust >= T.
+GHOST_HUNT_COND: dict[str, tuple[str, int]] = {
+    "Shade":       ("sanity_max", 35),
+    "Spirit":      ("lust_min",   50),
+    "Poltergeist": ("sanity_max", 50),
+    "Phantom":     ("sanity_max", 50),
+    "Goryo":       ("lust_min",   50),
+    "Demon":       ("sanity_max", 70),
+    "Deogen":      ("sanity_max", 50),
+    "Jinn":        ("sanity_max", 50),
+    "Moroi":       ("sanity_max", 50),
+    "Myling":      ("lust_min",   50),
+    "Oni":         ("lust_min",   50),
+    "Mimic":       ("sanity_max", 50),
+    "The Twins":   ("lust_min",   50),
+    "Wraith":      ("lust_min",   50),
+    "Mare":        ("lust_min",   50),
+    "Cthulion":    ("sanity_max", 50),
+    "Banshee":     ("lust_min",   50),
+    "Raiju":       ("sanity_max", 50),
+}
+
+
+def can_hunt(name: str, sanity: float, lust: float) -> bool:
+    kind, threshold = GHOST_HUNT_COND[name]
+    return sanity <= threshold if kind == "sanity_max" else lust >= threshold
+
+# Ghost override rules for Hide.tw / RunFast.tw. None = default 50/50 roll.
+GHOST_HIDE_SUCCESS = {"Deogen": False, "Jinn": True}
+GHOST_RUN_SUCCESS  = {"Deogen": True,  "Jinn": False}
+
+# setup.TIER_CHANCE (per-roll success for gwb / plasm / spiritbox).
+TIER_CHANCE = {5: 0.15, 4: 0.25, 3: 0.35}
+
+# setup.TOOL_TIME_REMAIN (in-game minutes the emf / uvl window stays open).
+TOOL_WINDOW = {5: 10, 4: 15, 3: 20}
+
+# HauntConditions constants.
+ENERGY_PER_STEP = 0.25
+START_ENERGY = 10.0
+START_SANITY = 100
+START_LUST = 0
+STEP_MINUTES = 1
+GHOST_MOVE_CHANCE = 0.35
+GHOST_EVENT_CHANCE_PER_STEP = 0.05  # approximates ArtEvent* / EventMC etc.
+HUNT_BASE_THRESHOLD = 6             # CheckHuntStart.tw: 6 + huntChanceBonus
+HUNT_EVENT_SANITY_LOSS = (1, 5)     # Ghost.rollEventSanityLoss default
+HIDE_SUCCESS_BASE = 0.50            # Hide.tw threshold (checkH <= 50)
+RUN_SUCCESS_BASE  = 0.70            # RunFast.tw threshold (check > 30)
+
+# Dark = room.background === 2 (lights off).
+LIGHT_ON, LIGHT_OFF = 1, 2
+
+
+@dataclass
+class Mc:
+    sanity: float = START_SANITY
+    lust: float = START_LUST
+    energy: float = START_ENERGY
+
+
+@dataclass
+class Hunt:
+    ghost_name: str
+    tier: int = 3
+    rooms: list[str] = field(default_factory=lambda: list(ELM_ROOMS))
+    mc: Mc = field(default_factory=Mc)
+    minutes: int = 0
+    ghost_room: str = ""
+    current_room: str = ""
+    last_move_interval: str = ""
+    emf_until: int = -1
+    uvl_until: int = -1
+    found: set[str] = field(default_factory=set)
+
+    # Haunt state
+    lights: dict[str, int] = field(default_factory=dict)   # room -> LIGHT_*
+    tshirt: bool = True
+    bottom: bool = True       # jeans/shorts/skirt worn
+    panties: bool = True
+    overcharged: bool = False
+    hunt_active_flag: bool = False   # $huntActivated
+    exit_reason: str = ""
+
+    def __post_init__(self) -> None:
+        self.ghost_room = random.choice(self.rooms)
+        self.current_room = random.choice(self.rooms)
+        self.last_move_interval = self._interval()
+        self.lights = {r: LIGHT_ON for r in self.rooms}
+
+    # --- snapshots / state queries ------------------------------------
+    @property
+    def ghost_evidence(self) -> frozenset[str]:
+        return GHOST_EVIDENCE[self.ghost_name]
+
+    @property
+    def clothing(self) -> str:
+        if not self.tshirt and not self.bottom and not self.panties:
+            return "nude"
+        if not self.tshirt and self.bottom:
+            return "topless"
+        if self.tshirt and self.bottom:
+            return "dressed"
+        return "partial"
+
+    @property
+    def dark(self) -> bool:
+        return self.lights.get(self.current_room, LIGHT_ON) == LIGHT_OFF
+
+    def snapshot(self) -> dict:
+        """Mirror of setup.HauntConditions.snapshot()."""
+        snap = dict(sanity_per_step=0, lust_per_step=0,
+                    tool_chance_bonus=0.0, tool_window_bonus=0,
+                    hunt_chance_bonus=0)
+        if self.dark:
+            snap["sanity_per_step"] -= 1
+            snap["tool_chance_bonus"] += 0.10
+            snap["tool_window_bonus"] += 5
+            snap["hunt_chance_bonus"] += 6
+        c = self.clothing
+        if c == "topless":
+            snap["tool_chance_bonus"] += 0.05
+            snap["lust_per_step"]     += 1
+            snap["hunt_chance_bonus"] += 3
+        elif c == "nude":
+            snap["tool_chance_bonus"] += 0.10
+            snap["lust_per_step"]     += 2
+            snap["hunt_chance_bonus"] += 5
+        if self.mc.lust >= 50:
+            snap["tool_chance_bonus"] += 0.05
+            snap["hunt_chance_bonus"] += 3
+        if self.overcharged:
+            snap["tool_chance_bonus"] += 0.10
+            snap["tool_window_bonus"] += 5
+            snap["hunt_chance_bonus"] += 5
+            snap["sanity_per_step"]   -= 1
+        return snap
+
+    # --- time / ghost bookkeeping -------------------------------------
+    def _interval(self) -> str:
+        m = self.minutes % 60
+        return "0-19" if m < 20 else "20-39" if m < 40 else "40-59"
+
+    def _maybe_move_ghost(self) -> None:
+        i = self._interval()
+        if i != self.last_move_interval:
+            if random.random() < GHOST_MOVE_CHANCE:
+                self.ghost_room = random.choice(self.rooms)
+            self.last_move_interval = i
+
+    def out_of_energy(self) -> bool:
+        return self.mc.energy <= 0
+
+    # --- navigation ---------------------------------------------------
+    def move_to(self, room: str) -> str | None:
+        """Walk to a room, paying energy/time, applying tick effects,
+        rolling for ghost events and random hunts. Returns an exit-reason
+        string if the hunt ends this tick ("sanity_zero", "caught_in_hunt"),
+        else None."""
+        self.current_room = room
+        self.minutes += STEP_MINUTES
+        self.mc.energy -= ENERGY_PER_STEP
+        self._maybe_move_ghost()
+
+        # Per-step tick effects (HauntConditions.applyTickEffects).
+        snap = self.snapshot()
+        self.mc.sanity = clamp(self.mc.sanity + snap["sanity_per_step"], 1, START_SANITY)
+        self.mc.lust   = clamp(self.mc.lust + snap["lust_per_step"], 0, 100)
+        # Sanity never hits 0 via natural drain (min clamp 1); the hunt-over
+        # -sanity exit comes from GhostHuntEvent's rollEventSanityLoss. We
+        # still surface sanity_zero if some future sink drives it below 1.
+
+        # Ghost event (activates tools).
+        if random.random() < GHOST_EVENT_CHANCE_PER_STEP:
+            self._activate("uvl")
+            self._activate("emf")
+
+        # Random ghost-hunt roll (CheckHuntStart.tw).
+        if not self.hunt_active_flag and can_hunt(
+                self.ghost_name, self.mc.sanity, self.mc.lust):
+            threshold = HUNT_BASE_THRESHOLD + snap["hunt_chance_bonus"]
+            if random.randint(0, 100) <= threshold:
+                reason = self._resolve_hunt_event()
+                if reason:
+                    return reason
+        return None
+
+    def _resolve_hunt_event(self) -> str | None:
+        """GhostHuntEvent.tw: AI hides. Returns exit reason if caught,
+        else None (hunt passed, event marker set)."""
+        self.hunt_active_flag = True
+        # Sanity event loss on hunt start.
+        lo, hi = HUNT_EVENT_SANITY_LOSS
+        self.mc.sanity -= random.randint(lo, hi)
+        if self.mc.sanity < 1:
+            self.mc.sanity = 0
+            return "sanity_zero"
+        # Hide (AI's default). Ghost override beats the roll.
+        override = GHOST_HIDE_SUCCESS.get(self.ghost_name)
+        if override is True:
+            survived = True
+        elif override is False:
+            survived = False
+        else:
+            survived = random.random() < HIDE_SUCCESS_BASE
+        if not survived:
+            return "caught_in_hunt"
+        # Survived - ghost event bumps both timed tools (like FreezeHunt).
+        self._activate("emf")
+        self._activate("uvl")
+        # After the event, the hunt-trigger clock resets (huntActivated=1;
+        # next CheckHuntStart waits for elapsedTimeHunt >= huntTimeRemain).
+        # Approximate with a 60-minute cooldown window expressed as
+        # "no new hunt this step"; next step we re-arm the flag.
+        self.hunt_active_flag = False
+        return None
+
+    # --- tool rolls ----------------------------------------------------
+    def _activate(self, tool: str) -> None:
+        window = TOOL_WINDOW[self.tier] + self.snapshot()["tool_window_bonus"]
+        until = self.minutes + window
+        if tool == "emf":
+            self.emf_until = max(self.emf_until, until)
+        else:
+            self.uvl_until = max(self.uvl_until, until)
+
+    def _roll_tier(self) -> bool:
+        bonus = self.snapshot()["tool_chance_bonus"]
+        return random.random() < TIER_CHANCE[self.tier] + bonus
+
+    def temperature_scan(self) -> int:
+        base = random.randint(13, 16)
+        offset = 0
+        if self.current_room == self.ghost_room:
+            offset = 8 if "temperature" in self.ghost_evidence else 5
+            if "temperature" in self.ghost_evidence:
+                self.found.add("temperature")
+        return base + offset
+
+    def gwb_scan(self) -> bool:
+        if self.current_room != self.ghost_room or "gwb" not in self.ghost_evidence:
+            return False
+        if self._roll_tier():
+            self.found.add("gwb")
+            self._activate("emf")
+            return True
+        return False
+
+    def plasm_scan(self) -> bool:
+        if self.current_room != self.ghost_room or "glass" not in self.ghost_evidence:
+            return False
+        if self._roll_tier():
+            self.found.add("glass")
+            return True
+        return False
+
+    def spiritbox_scan(self) -> bool:
+        if self.current_room != self.ghost_room or "spiritbox" not in self.ghost_evidence:
+            return False
+        if self._roll_tier():
+            self.found.add("spiritbox")
+            self._activate("emf")
+            return True
+        return False
+
+    def emf_scan(self) -> bool:
+        if self.current_room != self.ghost_room or "emf" not in self.ghost_evidence:
+            return False
+        if self.minutes > self.emf_until:
+            return False
+        self.found.add("emf")
+        return True
+
+    def uvl_scan(self) -> bool:
+        if self.current_room != self.ghost_room or "uvl" not in self.ghost_evidence:
+            return False
+        if self.minutes > self.uvl_until:
+            return False
+        self.found.add("uvl")
+        return True
+
+
+def clamp(x: float, lo: float, hi: float) -> float:
+    if x < lo: return lo
+    if x > hi: return hi
+    return x
+
+
+# ---- AI patterns -----------------------------------------------------
+
+SANITY_DANGER = 40            # below this, AI reverts to safe mode
+LUST_DANGER   = 45            # below the 50 threshold - AI keeps clothes on
+                              # to avoid crossing it and enabling more hunts
+
+
+def pattern_find_ghost_room(hunt: Hunt) -> tuple[str | None, str]:
+    """Walk rooms with lights ON (safer). Elevated temperature means the
+    ghost's room. Returns (room, reason) where reason is one of
+    'found' / 'energy' / 'sanity_zero' / 'caught_in_hunt' / 'search_timeout'."""
+    seen_cold: set[str] = set()
+    tried = 0
+    while tried < len(hunt.rooms) * 2:
+        if hunt.out_of_energy():
+            return None, "energy"
+        candidates = [r for r in hunt.rooms if r not in seen_cold]
+        if not candidates:
+            seen_cold.clear()
+            candidates = list(hunt.rooms)
+        dest = random.choice(candidates)
+        # Safety: keep lights on while scouting.
+        hunt.lights[dest] = LIGHT_ON
+        exit_reason = hunt.move_to(dest)
+        if exit_reason:
+            return None, exit_reason
+        reading = hunt.temperature_scan()
+        if reading >= 18:
+            return dest, "found"
+        seen_cold.add(dest)
+        tried += 1
+    return None, "search_timeout"
+
+
+def pattern_scan_for_evidence(hunt: Hunt, suspected: str, rounds: int = 6
+                              ) -> tuple[bool, str | None]:
+    """Scan every tool each round. Turns lights off for the tool bonus
+    unless sanity is already below SANITY_DANGER. Returns (complete,
+    exit_reason). complete=True when the evidence set is fully confirmed."""
+    for _ in range(rounds):
+        if hunt.out_of_energy():
+            return hunt.found >= hunt.ghost_evidence, "energy"
+        # Dynamic safety: lights off unless sanity is near-critical.
+        hunt.lights[suspected] = (LIGHT_OFF if hunt.mc.sanity > SANITY_DANGER
+                                  else LIGHT_ON)
+        exit_reason = hunt.move_to(suspected)
+        if exit_reason:
+            return hunt.found >= hunt.ghost_evidence, exit_reason
+        # Tool pass. GWB / Spiritbox roll before EMF so their hits can
+        # open the EMF window in the same pass.
+        hunt.temperature_scan()
+        hunt.gwb_scan()
+        hunt.spiritbox_scan()
+        hunt.plasm_scan()
+        hunt.emf_scan()
+        hunt.uvl_scan()
+        if hunt.found >= hunt.ghost_evidence:
+            return True, None
+    return hunt.found >= hunt.ghost_evidence, None
+
+
+def play_hunt(ghost_name: str, tier: int = 3) -> tuple[bool, set[str], str]:
+    """Run one contract with the simple AI. Returns
+    (identified, evidence_seen, exit_reason). exit_reason in
+    {identified, energy, sanity_zero, caught_in_hunt, search_timeout}."""
+    hunt = Hunt(ghost_name=ghost_name, tier=tier)
+
+    while not hunt.out_of_energy() and hunt.found < hunt.ghost_evidence:
+        suspected, reason = pattern_find_ghost_room(hunt)
+        if suspected is None:
+            hunt.exit_reason = reason
+            break
+        complete, scan_reason = pattern_scan_for_evidence(hunt, suspected,
+                                                           rounds=6)
+        if complete:
+            hunt.exit_reason = "identified"
+            break
+        if scan_reason:
+            hunt.exit_reason = scan_reason
+            break
+        # Evidence incomplete but no hard exit -- probably ghost relocated
+        # or tools missed. Loop re-searches.
+
+    identified = hunt.found == hunt.ghost_evidence
+    reason = hunt.exit_reason or ("identified" if identified else "energy")
+    return identified, set(hunt.found), reason
+
+
+# ---- Runner ----------------------------------------------------------
+
+
+@dataclass
+class Result:
+    ghost: str
+    trials: int
+    tier: int
+    wins: int
+    evidence_counts: dict[str, int]
+    count_by_found: list[int]
+    fail_reasons: dict[str, int]
+    missed_evidence: dict[tuple[str, ...], int]
+
+
+def simulate(ghost_name: str, trials: int, tier: int) -> Result:
+    if ghost_name not in GHOST_EVIDENCE:
+        raise SystemExit(f"Unknown ghost: {ghost_name!r}. "
+                         f"Choose from {sorted(GHOST_EVIDENCE)} or 'all'.")
+    if tier not in TIER_CHANCE:
+        raise SystemExit(f"Unknown tier: {tier}. Choose 3, 4, or 5.")
+
+    wins = 0
+    evidence_counts = {e: 0 for e in {"emf", "gwb", "glass",
+                                       "spiritbox", "temperature", "uvl"}}
+    count_by_found = [0] * 4
+    fail_reasons: dict[str, int] = {
+        "energy": 0, "sanity_zero": 0, "caught_in_hunt": 0, "search_timeout": 0,
+    }
+    missed_evidence: dict[tuple[str, ...], int] = {}
+
+    for _ in range(trials):
+        ok, found, reason = play_hunt(ghost_name, tier=tier)
+        if ok:
+            wins += 1
+        else:
+            fail_reasons[reason] = fail_reasons.get(reason, 0) + 1
+            missing = tuple(sorted(GHOST_EVIDENCE[ghost_name] - found))
+            missed_evidence[missing] = missed_evidence.get(missing, 0) + 1
+        for e in found:
+            evidence_counts[e] += 1
+        count_by_found[min(len(found & GHOST_EVIDENCE[ghost_name]), 3)] += 1
+
+    return Result(ghost_name, trials, tier, wins, evidence_counts,
+                  count_by_found, fail_reasons, missed_evidence)
+
+
+def print_detailed(r: Result) -> None:
+    target = sorted(GHOST_EVIDENCE[r.ghost])
+    losses = r.trials - r.wins
+    print(f"Elm Street AI hunt - {r.trials} runs vs {r.ghost} (tier {r.tier})")
+    print(f"  target evidence: {target}")
+    print(f"  identified correctly: {r.wins}/{r.trials} "
+          f"({100 * r.wins / r.trials:.2f}%)")
+    print("  evidence-piece hit rate (per run):")
+    for ev in target:
+        pct = 100 * r.evidence_counts[ev] / r.trials
+        print(f"    {ev:<12} {pct:6.2f}%")
+    print("  runs ending with N-of-3 target evidence collected:")
+    for n, c in enumerate(r.count_by_found):
+        print(f"    {n}/3: {c:>6}  ({100 * c / r.trials:5.2f}%)")
+    if losses:
+        print(f"  failure reasons ({losses} failed runs):")
+        for reason, c in sorted(r.fail_reasons.items(), key=lambda kv: -kv[1]):
+            pct_fail = 100 * c / losses
+            pct_all = 100 * c / r.trials
+            print(f"    {reason:<16} {c:>6}  ({pct_fail:5.2f}% of fails, "
+                  f"{pct_all:5.2f}% of runs)")
+        print("  missing evidence on failed runs:")
+        items = sorted(r.missed_evidence.items(), key=lambda kv: -kv[1])
+        for miss, c in items:
+            label = ", ".join(miss) if miss else "(none - but mis-matched)"
+            pct_fail = 100 * c / losses
+            print(f"    missing {label:<30} {c:>6}  ({pct_fail:5.2f}% of fails)")
+    else:
+        print("  failure reasons: (no failures)")
+
+
+def _top_reason(reasons: dict[str, int]) -> tuple[str, int]:
+    nonzero = [(k, v) for k, v in reasons.items() if v > 0]
+    if not nonzero:
+        return ("none", 0)
+    return max(nonzero, key=lambda kv: kv[1])
+
+
+def print_summary(results: list[Result]) -> None:
+    trials = results[0].trials
+    tier = results[0].tier
+    total_runs = sum(r.trials for r in results)
+    total_wins = sum(r.wins for r in results)
+    overall_reasons: dict[str, int] = {}
+    for r in results:
+        for k, v in r.fail_reasons.items():
+            overall_reasons[k] = overall_reasons.get(k, 0) + v
+
+    print(f"Elm Street AI hunt - {trials} runs per ghost, tier {tier}, "
+          f"{len(results)} ghosts ({total_runs} runs total)")
+    print()
+    header = f"  {'ghost':<13} {'success':>8}   {'top failure':<24}"
+    print(header)
+    print(f"  {'-' * 13} {'-' * 8}   {'-' * 24}")
+    # Worst ghosts first so the interesting ones are easy to spot.
+    for r in sorted(results, key=lambda x: x.wins / x.trials):
+        rate = 100 * r.wins / r.trials
+        fails = r.trials - r.wins
+        if fails:
+            reason, count = _top_reason(r.fail_reasons)
+            miss, miss_count = max(r.missed_evidence.items(),
+                                    key=lambda kv: kv[1])
+            miss_label = "+".join(miss) if miss else "none"
+            top = (f"{reason} {count}/{fails}"
+                   f" (miss {miss_label} {miss_count})")
+        else:
+            top = "-"
+        print(f"  {r.ghost:<13} {rate:>7.2f}%   {top:<24}")
+
+    print()
+    overall_rate = 100 * total_wins / total_runs
+    print(f"  overall success: {total_wins}/{total_runs} ({overall_rate:.2f}%)")
+    total_fails = total_runs - total_wins
+    if total_fails:
+        top_reason, top_count = _top_reason(overall_reasons)
+        print(f"  overall top failure: {top_reason} "
+              f"({top_count}/{total_fails} fails, "
+              f"{100 * top_count / total_runs:.2f}% of runs)")
+        ordered = sorted(overall_reasons.items(), key=lambda kv: -kv[1])
+        breakdown = ", ".join(f"{k}={v}" for k, v in ordered if v)
+        print(f"  failure breakdown: {breakdown}")
+    else:
+        print("  overall top failure: none")
+
+
+def main() -> None:
+    arg = sys.argv[1] if len(sys.argv) > 1 else "all"
+    if arg == "all":
+        trials = int(sys.argv[2]) if len(sys.argv) > 2 else 5000
+        tier = int(sys.argv[3]) if len(sys.argv) > 3 else 3
+        results = [simulate(name, trials, tier)
+                   for name in GHOST_EVIDENCE]
+        print_summary(results)
+    else:
+        trials = int(sys.argv[2]) if len(sys.argv) > 2 else 10000
+        tier = int(sys.argv[3]) if len(sys.argv) > 3 else 3
+        print_detailed(simulate(arg, trials, tier))
+
+
+if __name__ == "__main__":
+    main()

--- a/sim_ai_hunt.py
+++ b/sim_ai_hunt.py
@@ -173,11 +173,11 @@ def _parse_snapshot_bonuses(src: str) -> dict[str, dict[str, float]]:
         "overcharged": r'if \(snap\.overchargedTools\)\s*\{([^}]+)\}',
     }
     fields = {
-        "sanity_per_step":  r'snap\.sanityPerStep\s*([+\-])=\s*(\d+)',
-        "lust_per_step":    r'snap\.lustPerStep\s*([+\-])=\s*(\d+)',
-        "tool_chance":      r'snap\.toolChanceBonus\s*([+\-])=\s*(\d+)',
-        "tool_window":      r'snap\.toolWindowBonus\s*([+\-])=\s*(\d+)',
-        "hunt_chance":      r'snap\.huntChanceBonus\s*([+\-])=\s*(\d+)',
+        "sanity_per_step":  r'snap\.sanityPerStep\s*([+\-])=\s*([\d.]+)',
+        "lust_per_step":    r'snap\.lustPerStep\s*([+\-])=\s*([\d.]+)',
+        "tool_chance":      r'snap\.toolChanceBonus\s*([+\-])=\s*([\d.]+)',
+        "tool_window":      r'snap\.toolWindowBonus\s*([+\-])=\s*([\d.]+)',
+        "hunt_chance":      r'snap\.huntChanceBonus\s*([+\-])=\s*([\d.]+)',
     }
     out: dict[str, dict[str, float]] = {}
     for name, block_re in branches.items():
@@ -190,9 +190,21 @@ def _parse_snapshot_bonuses(src: str) -> dict[str, dict[str, float]]:
             fm = re.search(pat, body)
             if fm:
                 sign = 1 if fm.group(1) == "+" else -1
-                deltas[f] = sign * int(fm.group(2))
+                deltas[f] = sign * float(fm.group(2))
         out[name] = deltas
     return out
+
+
+def _parse_contract_drain(src: str) -> tuple[float, float]:
+    """Pull the `hasCompanion ? X : Y` ternary out of the contract-drain
+    block in HauntConditions.snapshot(). Returns (base_drain, companion_drain)
+    so the no-companion case is always first."""
+    m = re.search(
+        r"hasCompanion\s*\?\s*([\d.]+)\s*:\s*([\d.]+)\s*;", src)
+    if not m:
+        raise SystemExit("parser: contract drain ternary not found")
+    companion_drain, base_drain = float(m.group(1)), float(m.group(2))
+    return base_drain, companion_drain
 
 
 def _parse_houses() -> dict[str, list[str]]:
@@ -223,6 +235,8 @@ class GameData:
     lust_fuel_threshold: int
     dark_bg: int
     snapshot_bonuses: dict[str, dict[str, float]]
+    contract_sanity_drain: float             # baseline sanity -= /step in-house
+    contract_sanity_drain_with_companion: float
     ghost_event_chance_per_step: float = 0.05  # not encoded as a single
                                                # constant in-game; keeps the
                                                # ArtEvent/EventMC/Freeze
@@ -250,6 +264,7 @@ def load_game_data() -> GameData:
                               story_script))
     dark_bg = int(_find_num(r"var\s+DARK\s*=\s*(\d+)", story_script))
     snapshot_bonuses = _parse_snapshot_bonuses(story_script)
+    contract_drain, companion_drain = _parse_contract_drain(story_script)
 
     # mc starting stats (StoryInit.tw).
     start_sanity = _find_num(r"sanity\s*:\s*(\d+)", story_init)
@@ -286,6 +301,8 @@ def load_game_data() -> GameData:
         lust_fuel_threshold=lust_fuel,
         dark_bg=dark_bg,
         snapshot_bonuses=snapshot_bonuses,
+        contract_sanity_drain=contract_drain,
+        contract_sanity_drain_with_companion=companion_drain,
     )
 
 
@@ -380,14 +397,29 @@ def validate_game_data() -> list[str]:
             require(any(v != 0 for v in d.values()),
                     f"snapshot branch {branch!r} has no nonzero deltas: {d}")
 
-    # Spot-check: a run should execute without crashing in each house.
+    # Contract-drain ternary: companion arm must be no worse than the
+    # no-companion arm (the whole point of the companion bonus), and both
+    # must be positive - zero drain would silently defeat the gate-opening
+    # mechanic that landed this whole change.
+    require(GD.contract_sanity_drain > 0,
+            f"contract sanity drain {GD.contract_sanity_drain} must be > 0")
+    require(0 < GD.contract_sanity_drain_with_companion
+            <= GD.contract_sanity_drain,
+            f"companion contract drain "
+            f"{GD.contract_sanity_drain_with_companion} must be in "
+            f"(0, {GD.contract_sanity_drain}]")
+
+    # Spot-check: a run should execute without crashing in each house,
+    # with and without a companion.
     ghost = next(iter(GD.ghosts))
     for house in GD.houses:
-        try:
-            play_hunt(ghost, house=house, tier=3)
-        except Exception as e:
-            errors.append(
-                f"smoke run in {house} raised {type(e).__name__}: {e}")
+        for companion in (False, True):
+            try:
+                play_hunt(ghost, house=house, tier=3, companion=companion)
+            except Exception as e:
+                errors.append(
+                    f"smoke run in {house} (companion={companion}) raised "
+                    f"{type(e).__name__}: {e}")
 
     return errors
 
@@ -417,6 +449,7 @@ class Hunt:
     ghost_name: str
     house: str = "elm"
     tier: int = 3
+    companion: bool = False
     rooms: list[str] = field(default_factory=list)
     mc: Mc = field(default_factory=Mc)
     minutes: int = 0
@@ -472,6 +505,11 @@ class Hunt:
         snap = dict(sanity_per_step=0.0, lust_per_step=0.0,
                     tool_chance_bonus=0.0, tool_window_bonus=0.0,
                     hunt_chance_bonus=0.0)
+        # Contract-drain branch: always active inside a hunt (Hunt is the
+        # in-house context). Companion halves the drain.
+        snap["sanity_per_step"] -= (GD.contract_sanity_drain_with_companion
+                                    if self.companion
+                                    else GD.contract_sanity_drain)
         active: list[str] = []
         if self.dark:
             active.append("dark")
@@ -717,12 +755,14 @@ def pattern_scan_for_evidence(hunt: Hunt, suspected: str, rounds: int = 6
     return hunt.found >= hunt.ghost_evidence, None
 
 
-def play_hunt(ghost_name: str, house: str = "elm", tier: int = 3
+def play_hunt(ghost_name: str, house: str = "elm", tier: int = 3,
+              companion: bool = False
               ) -> tuple[bool, set[str], str]:
     """Run one contract with the simple AI. Returns
     (identified, evidence_seen, exit_reason). exit_reason in
     {identified, energy, sanity_zero, caught_in_hunt, search_timeout}."""
-    hunt = Hunt(ghost_name=ghost_name, house=house, tier=tier)
+    hunt = Hunt(ghost_name=ghost_name, house=house, tier=tier,
+                companion=companion)
 
     while not hunt.out_of_energy() and hunt.found < hunt.ghost_evidence:
         suspected, reason = pattern_find_ghost_room(hunt)
@@ -754,6 +794,7 @@ class Result:
     house: str
     trials: int
     tier: int
+    companion: bool
     wins: int
     evidence_counts: dict[str, int]
     count_by_found: list[int]
@@ -761,7 +802,13 @@ class Result:
     missed_evidence: dict[tuple[str, ...], int]
 
 
-def simulate(ghost_name: str, house: str, trials: int, tier: int) -> Result:
+# Sim-scoped flag flipped by --companion. Used as the default for every
+# subsequent `simulate()` call; avoids threading it through every CLI branch.
+SIM_COMPANION = False
+
+
+def simulate(ghost_name: str, house: str, trials: int, tier: int,
+             companion: bool | None = None) -> Result:
     if ghost_name not in GD.ghosts:
         raise SystemExit(f"Unknown ghost: {ghost_name!r}. "
                          f"Choose from {sorted(GD.ghosts)} or 'all'.")
@@ -772,6 +819,7 @@ def simulate(ghost_name: str, house: str, trials: int, tier: int) -> Result:
         raise SystemExit(f"Unknown tier: {tier}. "
                          f"Choose from {sorted(GD.tier_chance)}.")
 
+    comp: bool = SIM_COMPANION if companion is None else companion
     target = ghost_evidence(ghost_name)
     wins = 0
     evidence_counts = {e: 0 for e in EVIDENCE_ENUM.values()}
@@ -782,7 +830,8 @@ def simulate(ghost_name: str, house: str, trials: int, tier: int) -> Result:
     missed_evidence: dict[tuple[str, ...], int] = {}
 
     for _ in range(trials):
-        ok, found, reason = play_hunt(ghost_name, house=house, tier=tier)
+        ok, found, reason = play_hunt(ghost_name, house=house, tier=tier,
+                                       companion=comp)
         if ok:
             wins += 1
         else:
@@ -793,8 +842,9 @@ def simulate(ghost_name: str, house: str, trials: int, tier: int) -> Result:
             evidence_counts[e] = evidence_counts.get(e, 0) + 1
         count_by_found[min(len(found & target), 3)] += 1
 
-    return Result(ghost_name, house, trials, tier, wins, evidence_counts,
-                  count_by_found, fail_reasons, missed_evidence)
+    return Result(ghost_name, house, trials, tier, comp, wins,
+                  evidence_counts, count_by_found, fail_reasons,
+                  missed_evidence)
 
 
 def print_detailed(r: Result) -> None:
@@ -990,6 +1040,9 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("--tier", type=int, default=3,
                    help="Equipment tier for gwb/plasm/spiritbox (3/4/5). "
                         "Default 3.")
+    p.add_argument("--companion", action="store_true",
+                   help="Model the AI with a companion along. Halves the "
+                        "baseline contract sanity drain per nav tick.")
     for flag, _attr, cast, help_text in _OVERRIDE_FIELDS:
         p.add_argument(flag, type=cast, default=None,
                        help=f"Override: {help_text}.")
@@ -1014,6 +1067,10 @@ def main() -> None:
         return
 
     notes = _apply_overrides(args)
+    global SIM_COMPANION
+    SIM_COMPANION = args.companion
+    if args.companion:
+        notes.append("companion=True")
     if args.tier not in GD.tier_chance:
         raise SystemExit(f"Unknown tier: {args.tier}. "
                          f"Choose from {sorted(GD.tier_chance)}.")

--- a/sim_ai_hunt.py
+++ b/sim_ai_hunt.py
@@ -52,6 +52,7 @@ Trailing positional args are [trials] [tier] on each form.
 
 from __future__ import annotations
 
+import argparse
 import random
 import re
 import sys
@@ -920,9 +921,85 @@ def run_all_houses(trials: int, tier: int) -> None:
     print_overall(all_results)
 
 
+# ---- Experimental overrides -----------------------------------------
+#
+# Every override mutates the parsed game data in-place before any Hunt is
+# constructed. Mc's default_factory reads GD.start_* lazily, so changing
+# those values here flows through to every subsequent contract.
+
+_OVERRIDE_FIELDS: list[tuple[str, str, type, str]] = [
+    # (flag,              GD attribute,              cast, help-text fragment)
+    ("--energy",          "start_energy",            float, "starting mc.energy"),
+    ("--sanity",          "start_sanity",            float, "starting mc.sanity"),
+    ("--lust",            "start_lust",              float, "starting mc.lust"),
+    ("--energy-per-step", "energy_per_step",         float, "energy drain per nav tick"),
+    ("--ghost-move-chance", "ghost_move_chance",     float, "P(ghost relocates) per 20-min interval"),
+    ("--ghost-event-chance", "ghost_event_chance_per_step", float,
+     "P(ghost event fires) per nav tick"),
+    ("--hunt-threshold",  "hunt_base_threshold",     int,   "CheckHuntStart base threshold (0-100)"),
+    ("--hide-success",    "hide_success_base",       float, "Hide.tw baseline success rate (0-1)"),
+    ("--run-success",     "run_success_base",        float, "RunFast.tw baseline success rate (0-1)"),
+    ("--lust-fuel-threshold", "lust_fuel_threshold", int,   "lust threshold for the passive tool bonus"),
+]
+
+
+def _apply_overrides(args: argparse.Namespace) -> list[str]:
+    """Apply any --flag overrides to GD and return a list of human-readable
+    '<field>=<value>' notes so headers can flag experimental runs."""
+    notes: list[str] = []
+    for flag, attr, _cast, _help in _OVERRIDE_FIELDS:
+        dest = flag.lstrip("-").replace("-", "_")
+        v = getattr(args, dest, None)
+        if v is not None:
+            setattr(GD, attr, v)
+            notes.append(f"{attr}={v}")
+    return notes
+
+
+def _print_overrides_banner(notes: list[str]) -> None:
+    if notes:
+        print(f"[overrides active] {', '.join(notes)}")
+        print()
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="sim_ai_hunt.py",
+        description="Simulate the simple AI playing haunted-house contracts. "
+                    "Mechanics are parsed live from the game's .tw source.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Positional TARGET forms:\n"
+            "  (omitted) / 'all'   -> every house x every ghost\n"
+            "  <house>             -> all ghosts in that house\n"
+            "  <house> <ghost>     -> detailed single combo\n"
+            "  <ghost>             -> that ghost across all houses\n"
+        ),
+    )
+    p.add_argument("target", nargs="?", default="all",
+                   help="'all' (default), a house id, or a ghost name.")
+    p.add_argument("target2", nargs="?", default=None,
+                   help="When TARGET is a house, the second arg can name "
+                        "a specific ghost for a detailed per-run report.")
+    p.add_argument("--validate-data", action="store_true",
+                   help="Check that the parser still finds every expected "
+                        "piece of game data, then exit.")
+    p.add_argument("--trials", type=int, default=None,
+                   help="Runs per (house, ghost). Default 3000 for 'all', "
+                        "5000 for single-house, 10000 for single combo.")
+    p.add_argument("--tier", type=int, default=3,
+                   help="Equipment tier for gwb/plasm/spiritbox (3/4/5). "
+                        "Default 3.")
+    for flag, _attr, cast, help_text in _OVERRIDE_FIELDS:
+        p.add_argument(flag, type=cast, default=None,
+                       help=f"Override: {help_text}.")
+    return p
+
+
 def main() -> None:
-    args = sys.argv[1:]
-    if args and args[0] == "--validate-data":
+    args = _build_parser().parse_args()
+
+    if args.validate_data:
         errors = validate_game_data()
         if errors:
             print("sim_ai_hunt.py: game-data validation FAILED "
@@ -936,41 +1013,52 @@ def main() -> None:
               f"{total_rooms} rooms, {len(GD.tier_chance)} tool tiers).")
         return
 
-    arg = args[0] if args else "all"
-    if arg == "all":
-        trials = int(args[1]) if len(args) > 1 else 3000
-        tier = int(args[2]) if len(args) > 2 else 3
-        run_all_houses(trials, tier)
-    elif arg in GD.houses:
-        # <house> [<ghost>] [trials] [tier] -- one house, either all ghosts
-        # or a specific ghost.
-        house = arg
-        if len(args) > 1 and args[1] in GD.ghosts:
-            ghost = args[1]
-            trials = int(args[2]) if len(args) > 2 else 10000
-            tier = int(args[3]) if len(args) > 3 else 3
-            print_detailed(simulate(ghost, house, trials, tier))
+    notes = _apply_overrides(args)
+    if args.tier not in GD.tier_chance:
+        raise SystemExit(f"Unknown tier: {args.tier}. "
+                         f"Choose from {sorted(GD.tier_chance)}.")
+
+    target, target2 = args.target, args.target2
+
+    if target == "all":
+        trials = args.trials if args.trials is not None else 3000
+        _print_overrides_banner(notes)
+        run_all_houses(trials, args.tier)
+    elif target in GD.houses:
+        house = target
+        if target2 is not None:
+            if target2 not in GD.ghosts:
+                raise SystemExit(
+                    f"Unknown ghost: {target2!r}. "
+                    f"Choose from {sorted(GD.ghosts)}.")
+            trials = args.trials if args.trials is not None else 10000
+            _print_overrides_banner(notes)
+            print_detailed(simulate(target2, house, trials, args.tier))
         else:
-            trials = int(args[1]) if len(args) > 1 else 5000
-            tier = int(args[2]) if len(args) > 2 else 3
-            results = [simulate(name, house, trials, tier)
-                       for name in GD.ghosts]
-            print(f"AI hunt - {trials} runs per ghost in {house} (tier {tier})")
+            trials = args.trials if args.trials is not None else 5000
+            _print_overrides_banner(notes)
+            print(f"AI hunt - {trials} runs per ghost in {house} "
+                  f"(tier {args.tier})")
             print()
-            # Full per-ghost listing when explicitly scoped to one house.
+            results = [simulate(name, house, trials, args.tier)
+                       for name in GD.ghosts]
             for r in sorted(results, key=lambda x: x.wins / x.trials):
                 rate, name, blurb = _row_for(r)
                 print(f"  {name:<13} {rate:>7.2f}%   {blurb}")
             print_overall(results)
-    elif arg in GD.ghosts:
-        # <ghost>: run it in every house for comparison.
-        ghost = arg
-        trials = int(args[1]) if len(args) > 1 else 5000
-        tier = int(args[2]) if len(args) > 2 else 3
+    elif target in GD.ghosts:
+        ghost = target
+        if target2 is not None:
+            raise SystemExit(
+                f"When TARGET is a ghost, TARGET2 isn't used (got "
+                f"{target2!r}). Put the house first: "
+                f"'sim_ai_hunt.py <house> {ghost}'.")
+        trials = args.trials if args.trials is not None else 5000
+        _print_overrides_banner(notes)
         print(f"AI hunt - {trials} runs vs {ghost} across "
-              f"{len(GD.houses)} houses (tier {tier})")
+              f"{len(GD.houses)} houses (tier {args.tier})")
         print()
-        results = [simulate(ghost, house, trials, tier)
+        results = [simulate(ghost, house, trials, args.tier)
                    for house in GD.houses]
         for r in sorted(results, key=lambda x: x.wins / x.trials):
             rate = 100 * r.wins / r.trials
@@ -985,7 +1073,7 @@ def main() -> None:
         print_overall(results)
     else:
         raise SystemExit(
-            f"Unknown arg: {arg!r}. Use 'all', a house id "
+            f"Unknown target: {target!r}. Use 'all', a house id "
             f"({sorted(GD.houses)}), or a ghost name "
             f"({sorted(GD.ghosts)}).")
 

--- a/tests/e2e/ghost-hunt-conditions.spec.js
+++ b/tests/e2e/ghost-hunt-conditions.spec.js
@@ -9,14 +9,14 @@ test.describe('Ghost hunt conditions', () => {
   test.afterAll(async () => { await page.close(); });
   test.beforeEach(async () => { await resetGame(page); });
 
-  test('Shade: hunt triggers only at sanity <= 35', async () => {
+  test('Shade: hunt triggers only at sanity <= 55', async () => {
     await setupHunt(page, 'Shade');
 
-    await setVar(page, 'mc.sanity', 40);
+    await setVar(page, 'mc.sanity', 60);
     expect(await callSetup(page,
       'setup.Ghosts.getByName("Shade").canHunt(SugarCube.State.variables.mc)')).toBe(false);
 
-    await setVar(page, 'mc.sanity', 35);
+    await setVar(page, 'mc.sanity', 55);
     expect(await callSetup(page,
       'setup.Ghosts.getByName("Shade").canHunt(SugarCube.State.variables.mc)')).toBe(true);
 
@@ -28,14 +28,14 @@ test.describe('Ghost hunt conditions', () => {
     await expectCleanPassage(page);
   });
 
-  test('Demon: hunt triggers at sanity <= 70 (more aggressive)', async () => {
+  test('Demon: hunt triggers at sanity <= 90 (most aggressive)', async () => {
     await setupHunt(page, 'Demon');
 
-    await setVar(page, 'mc.sanity', 75);
+    await setVar(page, 'mc.sanity', 95);
     expect(await callSetup(page,
       'setup.Ghosts.getByName("Demon").canHunt(SugarCube.State.variables.mc)')).toBe(false);
 
-    await setVar(page, 'mc.sanity', 70);
+    await setVar(page, 'mc.sanity', 90);
     expect(await callSetup(page,
       'setup.Ghosts.getByName("Demon").canHunt(SugarCube.State.variables.mc)')).toBe(true);
 
@@ -47,14 +47,14 @@ test.describe('Ghost hunt conditions', () => {
     await expectCleanPassage(page);
   });
 
-  test('Spirit: hunt condition requires lust >= 50', async () => {
+  test('Spirit: hunt condition requires lust >= 30', async () => {
     await setupHunt(page, 'Spirit');
 
-    await setVar(page, 'mc.lust', 40);
+    await setVar(page, 'mc.lust', 25);
     expect(await callSetup(page,
       'setup.Ghosts.getByName("Spirit").canHunt(SugarCube.State.variables.mc)')).toBe(false);
 
-    await setVar(page, 'mc.lust', 50);
+    await setVar(page, 'mc.lust', 30);
     expect(await callSetup(page,
       'setup.Ghosts.getByName("Spirit").canHunt(SugarCube.State.variables.mc)')).toBe(true);
 
@@ -62,14 +62,14 @@ test.describe('Ghost hunt conditions', () => {
     await expectCleanPassage(page);
   });
 
-  test('Poltergeist: hunt condition requires sanity <= 50', async () => {
+  test('Poltergeist: hunt condition requires sanity <= 70', async () => {
     await setupHunt(page, 'Poltergeist');
 
-    await setVar(page, 'mc.sanity', 55);
+    await setVar(page, 'mc.sanity', 75);
     expect(await callSetup(page,
       'setup.Ghosts.getByName("Poltergeist").canHunt(SugarCube.State.variables.mc)')).toBe(false);
 
-    await setVar(page, 'mc.sanity', 50);
+    await setVar(page, 'mc.sanity', 70);
     expect(await callSetup(page,
       'setup.Ghosts.getByName("Poltergeist").canHunt(SugarCube.State.variables.mc)')).toBe(true);
 
@@ -77,14 +77,14 @@ test.describe('Ghost hunt conditions', () => {
     await expectCleanPassage(page);
   });
 
-  test('Moroi: hunt condition requires sanity <= 50 and has spiritbox evidence', async () => {
+  test('Moroi: hunt condition requires sanity <= 70 and has spiritbox evidence', async () => {
     await setupHunt(page, 'Moroi');
 
-    await setVar(page, 'mc.sanity', 55);
+    await setVar(page, 'mc.sanity', 75);
     expect(await callSetup(page,
       'setup.Ghosts.getByName("Moroi").canHunt(SugarCube.State.variables.mc)')).toBe(false);
 
-    await setVar(page, 'mc.sanity', 50);
+    await setVar(page, 'mc.sanity', 70);
     expect(await callSetup(page,
       'setup.Ghosts.getByName("Moroi").canHunt(SugarCube.State.variables.mc)')).toBe(true);
 
@@ -95,14 +95,14 @@ test.describe('Ghost hunt conditions', () => {
     await expectCleanPassage(page);
   });
 
-  test('Myling: hunt condition requires lust >= 50', async () => {
+  test('Myling: hunt condition requires lust >= 30', async () => {
     await setupHunt(page, 'Myling');
 
-    await setVar(page, 'mc.lust', 45);
+    await setVar(page, 'mc.lust', 25);
     expect(await callSetup(page,
       'setup.Ghosts.getByName("Myling").canHunt(SugarCube.State.variables.mc)')).toBe(false);
 
-    await setVar(page, 'mc.lust', 50);
+    await setVar(page, 'mc.lust', 30);
     expect(await callSetup(page,
       'setup.Ghosts.getByName("Myling").canHunt(SugarCube.State.variables.mc)')).toBe(true);
 
@@ -110,14 +110,14 @@ test.describe('Ghost hunt conditions', () => {
     await expectCleanPassage(page);
   });
 
-  test('The Twins: hunt condition requires lust >= 50', async () => {
+  test('The Twins: hunt condition requires lust >= 30', async () => {
     await setupHunt(page, 'The Twins');
 
-    await setVar(page, 'mc.lust', 45);
+    await setVar(page, 'mc.lust', 25);
     expect(await callSetup(page,
       'setup.Ghosts.getByName("The Twins").canHunt(SugarCube.State.variables.mc)')).toBe(false);
 
-    await setVar(page, 'mc.lust', 50);
+    await setVar(page, 'mc.lust', 30);
     expect(await callSetup(page,
       'setup.Ghosts.getByName("The Twins").canHunt(SugarCube.State.variables.mc)')).toBe(true);
 
@@ -125,14 +125,14 @@ test.describe('Ghost hunt conditions', () => {
     await expectCleanPassage(page);
   });
 
-  test('Wraith: hunt condition requires lust >= 50', async () => {
+  test('Wraith: hunt condition requires lust >= 30', async () => {
     await setupHunt(page, 'Wraith');
 
-    await setVar(page, 'mc.lust', 45);
+    await setVar(page, 'mc.lust', 25);
     expect(await callSetup(page,
       'setup.Ghosts.getByName("Wraith").canHunt(SugarCube.State.variables.mc)')).toBe(false);
 
-    await setVar(page, 'mc.lust', 55);
+    await setVar(page, 'mc.lust', 35);
     expect(await callSetup(page,
       'setup.Ghosts.getByName("Wraith").canHunt(SugarCube.State.variables.mc)')).toBe(true);
 
@@ -140,14 +140,14 @@ test.describe('Ghost hunt conditions', () => {
     await expectCleanPassage(page);
   });
 
-  test('Mare: hunt condition requires lust >= 50', async () => {
+  test('Mare: hunt condition requires lust >= 30', async () => {
     await setupHunt(page, 'Mare');
 
-    await setVar(page, 'mc.lust', 45);
+    await setVar(page, 'mc.lust', 25);
     expect(await callSetup(page,
       'setup.Ghosts.getByName("Mare").canHunt(SugarCube.State.variables.mc)')).toBe(false);
 
-    await setVar(page, 'mc.lust', 50);
+    await setVar(page, 'mc.lust', 30);
     expect(await callSetup(page,
       'setup.Ghosts.getByName("Mare").canHunt(SugarCube.State.variables.mc)')).toBe(true);
 
@@ -155,14 +155,14 @@ test.describe('Ghost hunt conditions', () => {
     await expectCleanPassage(page);
   });
 
-  test('Banshee: hunt condition requires lust >= 50', async () => {
+  test('Banshee: hunt condition requires lust >= 30', async () => {
     await setupHunt(page, 'Banshee');
 
-    await setVar(page, 'mc.lust', 45);
+    await setVar(page, 'mc.lust', 25);
     expect(await callSetup(page,
       'setup.Ghosts.getByName("Banshee").canHunt(SugarCube.State.variables.mc)')).toBe(false);
 
-    await setVar(page, 'mc.lust', 50);
+    await setVar(page, 'mc.lust', 30);
     expect(await callSetup(page,
       'setup.Ghosts.getByName("Banshee").canHunt(SugarCube.State.variables.mc)')).toBe(true);
 
@@ -181,14 +181,14 @@ test.describe('Ghost hunt conditions', () => {
     await expectCleanPassage(page);
   });
 
-  test('Cthulion: hunt condition requires sanity <= 50', async () => {
+  test('Cthulion: hunt condition requires sanity <= 70', async () => {
     await setupHunt(page, 'Cthulion');
 
-    await setVar(page, 'mc.sanity', 55);
+    await setVar(page, 'mc.sanity', 75);
     expect(await callSetup(page,
       'setup.Ghosts.getByName("Cthulion").canHunt(SugarCube.State.variables.mc)')).toBe(false);
 
-    await setVar(page, 'mc.sanity', 50);
+    await setVar(page, 'mc.sanity', 70);
     expect(await callSetup(page,
       'setup.Ghosts.getByName("Cthulion").canHunt(SugarCube.State.variables.mc)')).toBe(true);
 
@@ -196,14 +196,14 @@ test.describe('Ghost hunt conditions', () => {
     await expectCleanPassage(page);
   });
 
-  test('Raiju: hunt condition requires sanity <= 50', async () => {
+  test('Raiju: hunt condition requires sanity <= 70', async () => {
     await setupHunt(page, 'Raiju');
 
-    await setVar(page, 'mc.sanity', 55);
+    await setVar(page, 'mc.sanity', 75);
     expect(await callSetup(page,
       'setup.Ghosts.getByName("Raiju").canHunt(SugarCube.State.variables.mc)')).toBe(false);
 
-    await setVar(page, 'mc.sanity', 50);
+    await setVar(page, 'mc.sanity', 70);
     expect(await callSetup(page,
       'setup.Ghosts.getByName("Raiju").canHunt(SugarCube.State.variables.mc)')).toBe(true);
 

--- a/tests/haunted-houses.spec.js
+++ b/tests/haunted-houses.spec.js
@@ -412,4 +412,93 @@ test.describe('Haunted Houses Controller', () => {
     // assert
     expect(result).toBe(false);
   });
+
+  // --- Hunt gates (huntCondition thresholds) ---
+  //
+  // The catalogue-wide gate widening lives in GhostController.tw: every
+  // huntCondition threshold was shifted 20 points toward "fires sooner"
+  // (sanity-gated: +20, lust-gated: -20). These tests pin each ghost's
+  // canHunt(mc) boundary so an accidental revert to the pre-change values
+  // fails here instead of silently re-tightening the gates.
+
+  const canHunt = (ghostName, sanity, lust) =>
+    callSetup(
+      page,
+      `setup.Ghosts.getByName(${JSON.stringify(ghostName)})` +
+        `.canHunt({ sanity: ${sanity}, lust: ${lust} })`,
+    );
+
+  test('Shade canHunt gate is sanity <= 55 (widened from 35)', async () => {
+    expect(await canHunt('Shade', 55, 0)).toBe(true);
+    expect(await canHunt('Shade', 56, 0)).toBe(false);
+  });
+
+  test('Demon canHunt gate is sanity <= 90 (widened from 70)', async () => {
+    expect(await canHunt('Demon', 90, 0)).toBe(true);
+    expect(await canHunt('Demon', 91, 0)).toBe(false);
+  });
+
+  test('Phantom canHunt gate is sanity <= 70 (widened from 50)', async () => {
+    expect(await canHunt('Phantom', 70, 0)).toBe(true);
+    expect(await canHunt('Phantom', 71, 0)).toBe(false);
+  });
+
+  test('Spirit canHunt gate is lust >= 30 (widened from 50)', async () => {
+    expect(await canHunt('Spirit', 100, 30)).toBe(true);
+    expect(await canHunt('Spirit', 100, 29)).toBe(false);
+  });
+
+  test('Banshee canHunt gate is lust >= 30 (widened from 50)', async () => {
+    expect(await canHunt('Banshee', 100, 30)).toBe(true);
+    expect(await canHunt('Banshee', 100, 29)).toBe(false);
+  });
+
+  // --- HauntConditions contract drain ---
+  //
+  // A contract is now mechanically costly: every nav tick inside a house
+  // drains sanity at 0.4/step, or 0.2/step when a companion is along.
+  // These tests lock the numbers in as a direct read of the snapshot;
+  // without them a regression silently weakens the hunt-gate pressure.
+
+  test('snapshot has no contract drain outside a house', async () => {
+    // arrange - no active hunt means isInsideHouse() returns false
+    await setHuntMode(page, 0);
+
+    // act
+    const drain = await callSetup(
+      page,
+      'setup.HauntConditions.snapshot().sanityPerStep',
+    );
+
+    // assert
+    expect(drain).toBe(0);
+  });
+
+  test('snapshot applies 0.4/step contract drain in-house without companion', async () => {
+    // arrange
+    await setHuntMode(page, 2); // inside a house
+    await setVar(page, 'isCompChosen', 0);
+
+    // act
+    const snap = await callSetup(page, 'setup.HauntConditions.snapshot()');
+
+    // assert
+    expect(snap.sanityPerStep).toBeCloseTo(-0.4, 5);
+    const labels = snap.contributors.map((c) => c.label);
+    expect(labels).toContain('Contract');
+  });
+
+  test('companion halves the contract drain to 0.2/step', async () => {
+    // arrange
+    await setHuntMode(page, 2);
+    await setVar(page, 'isCompChosen', 1);
+
+    // act
+    const snap = await callSetup(page, 'setup.HauntConditions.snapshot()');
+
+    // assert
+    expect(snap.sanityPerStep).toBeCloseTo(-0.2, 5);
+    const labels = snap.contributors.map((c) => c.label);
+    expect(labels).toContain('Contract (w/ companion)');
+  });
 });

--- a/tests/sim-ai-hunt-lint.spec.js
+++ b/tests/sim-ai-hunt-lint.spec.js
@@ -1,0 +1,28 @@
+const { test, expect } = require('@playwright/test');
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const SCRIPT = path.join(REPO_ROOT, 'sim_ai_hunt.py');
+
+/**
+ * sim_ai_hunt.py parses mechanics out of the live .tw source instead of
+ * hard-coding them. This test runs the script's --validate-data mode so any
+ * rename / restructure of the parsed bits (ghost config, TIER_CHANCE,
+ * HauntConditions snapshot, CheckHuntStart, Hide/RunFast thresholds, etc.)
+ * shows up as a failing test in CI before it silently desyncs the sim.
+ */
+test('sim_ai_hunt.py --validate-data finds all expected game data', () => {
+  const result = spawnSync('python3', [SCRIPT, '--validate-data'], {
+    cwd: REPO_ROOT,
+    encoding: 'utf-8',
+  });
+  const stdout = result.stdout || '';
+  const stderr = result.stderr || '';
+  expect(
+    result.status,
+    `sim_ai_hunt.py --validate-data exited ${result.status}\n` +
+      `stdout:\n${stdout}\nstderr:\n${stderr}`,
+  ).toBe(0);
+  expect(stdout).toContain('game-data validation OK');
+});


### PR DESCRIPTION
Every huntCondition threshold is shifted 20 points toward "fires sooner":
sanity-gated ghosts by +20 (Shade 35→55, Phantom/Poltergeist/Moroi/
Cthulion/Raiju/Mimic/Deogen/Jinn 50→70, Demon 70→90); lust-gated ghosts
by -20 (Spirit/Goryo/Myling/Oni/Twins/Wraith/Mare/Banshee 50→30).
huntConditionText strings and Demon's description updated to match.

HauntConditions.snapshot() now applies a baseline contract drain while
inside a house: -0.4 sanity/step, halved to -0.2/step when a companion
is along ($isCompChosen === 1). Pushed as a labeled contributor so the
HUD shows the drain alongside the existing dark/topless/nude/overcharged
badges.

Before this, the canHunt gate was effectively never open against
conservative play - the player could stay at starting sanity/lust for
the whole contract, so hunt rolls never even got to dice. Tightening
hide/run or raising the hunt threshold did nothing without opening the
gate. A passive sanity drain + wider gates means hunts actually engage,
and bringing a companion becomes a mechanically meaningful choice.

Also:
- sim_ai_hunt.py: standalone Python simulator that loads mechanics
  directly from the .tw source (GHOST_CONFIG, TIER_CHANCE,
  TOOL_TIME_REMAIN, HauntConditions snapshot, ChangeGhostRoom,
  CheckHuntStart, Hide/RunFast, StoryInit). Runs every ghost x every
  house by default, prints a compact top-2/bottom-2 table per house.
  Supports --validate-data for CI, --companion to model the bonus,
  and experimental --energy / --sanity / --hunt-threshold /
  --hide-success overrides.
- tests/sim-ai-hunt-lint.spec.js: runs --validate-data in the lint
  project so parser drift against the game sources fails CI.
- tests/haunted-houses.spec.js: new boundary tests for the widened
  canHunt gates and the new contract-drain snapshot branch (with and
  without companion).