### PR TITLE
add tick effects to tool render (#79)

### DIFF
--- a/passages/haunted_houses/tools/ToolController.tw
+++ b/passages/haunted_houses/tools/ToolController.tw
@@ -263,6 +263,7 @@
         var render = RENDERERS[toolKey];
         if (!render) throw new Error("toolCheck: unknown tool '" + toolKey + "'");
         var v = (variant === "art") ? "art" : "standard";
+        setup.HauntConditions.applyTickEffects();
         return render(v);
     }
 


### PR DESCRIPTION
Fixes the bug(?) I found where sanity doesn't decrease after using a tool. Makes the the same tick effects as switching rooms and searching furniture occur when a tool displays its result.