### PR TITLE
Added a 24 Hour and 12 Hour Time format to the game.

### DIFF
--- a/config/t3lt.twee-config.yml
+++ b/config/t3lt.twee-config.yml
@@ -450,6 +450,11 @@ sugarcube-2:
         earnedMoney increment, and the Back button. No args."
     addTime:
       name: addTime
+    displayTime:
+      name: displayTime
+      description: "Renders Text properly depending on users Time Format in Settings.
+        uses Military Time as an input aka 0000 is 12:00 AM, 0830 is 08:30 AM, 1821 is
+        16:21 PM"
     addLust:
       name: addLust
     backOrReturn:

--- a/passages/church/Church.tw
+++ b/passages/church/Church.tw
@@ -7,7 +7,7 @@
 <</if>>
 <br>
 <<if not setup.Church.isOpen()>>
-	@@.mc-thoughts; I came at an inappropriate time (open from 06:00 to 22:00)@@<br>
+	@@.mc-thoughts; I came at an inappropriate time (open from <<displayTime 0600>> to <<displayTime 2200>>)@@<br>
 <<else>>
 	<<if setup.Church.canStartNunQuest()>>
 		@@.mc-thoughts; Khadija sent me to find Sister Rain. Confession's how women get her in private.@@<br>

--- a/passages/church/ChurchNunQuest.tw
+++ b/passages/church/ChurchNunQuest.tw
@@ -11,9 +11,9 @@
 	@@.notmc-speech; Ask me in six months. If you're still alive.@@<br>
 	@@.mc-thoughts; She doesn't blink when she says it. You're not sure she blinks at all.@@<br>
 	@@.mc-speech; The missing girls?@@<br>
-	@@.notmc-speech; Board's outside, left of the door. Posters with names and pictures. <em><b>I refresh it at 18:00 every day</b></em>, after I hear which ones came home. Take a poster, and that's your assignment.<br><br>
+	@@.notmc-speech; Board's outside, left of the door. Posters with names and pictures. <em><b>I refresh it at <<displayTime 1800>> every day</b></em>, after I hear which ones came home. Take a poster, and that's your assignment.<br><br>
 	They get taken on <em><b>Owaissa or Elm</b></em>, then they end up <em><b>south, in the abandoned houses</b></em>. They don't walk there themselves. You can sweep the south door to door and burn a day on it, or you can <em><b>start on Owaissa or Elm and look for what points you to which house in the south</b></em>. Pick whichever you can afford.<br><br>
-	<em><b>You have until 18:00 the next day.</b></em> After that I send hunters who can actually get her out, so don't be later than that.<br><br>
+	<em><b>You have until <<displayTime 1800>> the next day.</b></em> After that I send hunters who can actually get her out, so don't be later than that.<br><br>
 	<em><b>The longer she's down there, the less of her is left to bring back. Take holy water. It's free.</b></em>@@<br>
 	@@.mc-speech; Got it.@@<br>
 	<br>

--- a/passages/church/ChurchNunQuest.tw
+++ b/passages/church/ChurchNunQuest.tw
@@ -13,7 +13,7 @@
 	<<mc>>The missing girls?<</mc>><br>
 	<<say>>Board's outside, left of the door. Posters with names and pictures. <em><b>I refresh it at <<displayTime 1800>> every day</b></em>, after I hear which ones came home. Take a poster, and that's your assignment.<br><br>
 		They get taken on <em><b>Owaissa or Elm</b></em>, then they end up <em><b>south, in the abandoned houses</b></em>. They don't walk there themselves. You can sweep the south door to door and burn a day on it, or you can <em><b>start on Owaissa or Elm and look for what points you to which house in the south</b></em>. Pick whichever you can afford.<br><br>
-		<em><b>You have until 18:00 the next day.</b></em> After that I send hunters who can actually get her out, so don't be later than that.<br><br>
+		<em><b>You have until <<displayTime 1800>> the next day.</b></em> After that I send hunters who can actually get her out, so don't be later than that.<br><br>
 		<em><b>The longer she's down there, the less of her is left to bring back. Take holy water. It's free.</b></em>
 	<</say>><br>
 	<<mc>>Got it.<</mc>><br>

--- a/passages/delivery/DeliveryHub.tw
+++ b/passages/delivery/DeliveryHub.tw
@@ -5,7 +5,7 @@
 @@.mc-thoughts; This is a small office in the city specializing in the delivery of various goods. It's one of the few places where you can earn some money@@<br>
 <br>
 <<if not setup.Delivery.isOpen()>>
-	@@.mc-thoughts;The delivery hub is not open right now (open from 08:00 to 20:00)@@
+	@@.mc-thoughts;The delivery hub is not open right now (open from <<displayTime 0800>> to <<displayTime 2000>>)@@
 <<else>>
 	<<if setup.Delivery.completedShifts() gt 0>>
 		<div class="delivery-stats">

--- a/passages/delivery/DeliveryManager.tw
+++ b/passages/delivery/DeliveryManager.tw
@@ -8,7 +8,7 @@
 
 	@@.mc-speech;Thank you. I'm ready to start. What do I need to do?@@<br>
 
-	@@.notmc-speech; Eager. <i>His eyes catch on your mouth for half a second.</i> That's what we like to see. Hours are 08:00 to 20:00, any day. I run a flexible shop here, none of the rigid stuff. You come in when you can, you take what's on the board. We take care of our people.@@<br>
+	@@.notmc-speech; Eager. <i>His eyes catch on your mouth for half a second.</i> That's what we like to see. Hours are <<displayTime 0800>> to <<displayTime 2000>>, any day. I run a flexible shop here, none of the rigid stuff. You come in when you can, you take what's on the board. We take care of our people.@@<br>
 
 	@@.mc-speech;Understood. How will I receive orders?@@<br>
 
@@ -34,7 +34,7 @@
 	<<else>>
 		@@.notmc-speech;
 		Hello, you're like umm... Susan? Milana? Doesn't matter, I'm a bit busy right now, let's talk later.
-		If you forgot, you can work here from 08:00 to 20:00. Take orders and go ahead. Good luck.@@
+		If you forgot, you can work here from <<displayTime 0800>> to <<displayTime 2000>>. Take orders and go ahead. Good luck.@@
 	<</if>>
 	<br>
 

--- a/passages/gui/ChangeLog.tw
+++ b/passages/gui/ChangeLog.tw
@@ -119,7 +119,7 @@ v.0.5.4
 	- Added cursed hunt. (You can replace it with a regular hunt (at the bottom of the guide))
 	- Now there is a chance to become possessed (Possessed card - very small chance, for now only this way)
 	- The completion time for follower tasks has been reduced
-	- Changed the possession system for missing girls (After 24:00, the chance of possession increases by about 5% for each hour)
+	- Changed the possession system for missing girls (After <<displayTime 0000>>, the chance of possession increases by about 5% for each hour)
 	- Prices for some tools from the witch have been reduced\
 <</linkreplace>>
 <<linkreplace "v.0.4.0">>
@@ -137,8 +137,8 @@ v.0.5.4
 	- Now fitness level affects energy. (Every 10 fitness points grants 1 energy)
 	- New Quest: Missing Girls. <<linkreplace "Spoiler">>\
 		There are currently 4 missing girls. The quest begins at the witch's house and continues at the church.
-		After speaking with the nun, a board displaying information about the missing girls appears. The board updates daily, and you can accept a quest from it after 18:00.
-		You must complete the quest by 18:00 the following day. If the quest is not completed by 12:00 the next day, the girl will become possessed and can no longer be saved.
+		After speaking with the nun, a board displaying information about the missing girls appears. The board updates daily, and you can accept a quest from it after <<displayTime 1800>>.
+		You must complete the quest by <<displayTime 1800>> the following day. If the quest is not completed by <<displayTime 1200>> the next day, the girl will become possessed and can no longer be saved.
 		<</linkreplace>>
 	- You can give sanity pills to your follower.
 	- Furniture has been added to haunted houses, where stolen clothes or cursed items can now be hidden.

--- a/passages/gui/Evidence.tw
+++ b/passages/gui/Evidence.tw
@@ -88,7 +88,7 @@ called <b>breaking and entering</b>. <b>You need a signed contract from a
 licensed provider</b> before trying to enter any haunted houses.
 </li>
 <li>
-<b>Hunts begin at 23:00.</b> Earlier than that, the house is just a house.
+<b>Hunts begin at <<displayTime 2300>>.</b> Earlier than that, the house is just a house.
 We do not maintain a lobby. <b>Wait at home.</b>
 </li>
 <li>
@@ -258,7 +258,7 @@ yours either way. Lucky you.
 </p>
 
 <p>
-Hunts run until <b>06:00</b>. If you are still inside at dawn, the
+Hunts run until <b><<displayTime 0600>></b>. If you are still inside at dawn, the
 house remembers. Norville & Co. has been forbidden by court order from
 describing what happens next.
 </p>

--- a/passages/gui/GuiController.js
+++ b/passages/gui/GuiController.js
@@ -250,6 +250,12 @@ Setting.addList("fontChoice", {
 });
 $(document).on(":passagestart", function () { setup.Gui.applyFontPreference(); });
 
+Setting.addList("timeFormat", {
+    label   : "Display Format for Time",
+    list    : ["24 Hour", "12 Hour"],
+    default : "24 Hour",
+});
+
 /* Stateful cheats are registered through SugarCube's Setting API
    because they have a meaningful persisted value (toggle on/off,
    list selection). They live under a single "Cheats" header,
@@ -319,11 +325,6 @@ $(document).one(":storyready", function () {
 		if (current === _offCheatValue[source]) return;
 		setup.StoryEvents.emit(setup.StoryEvents.Event.CHEAT_USED, { source: source });
 	};
-    Setting.addList("timeFormat", {
-        label   : "Display Format for Time",
-        list    : ["24 Hour", "12 Hour"],
-        default : "24 Hour",
-    });
 
 	Setting.addHeader(
 		"Cheats",

--- a/passages/gui/GuiController.js
+++ b/passages/gui/GuiController.js
@@ -318,7 +318,13 @@ $(document).one(":storyready", function () {
 		if (action) action();
 		if (current === _offCheatValue[source]) return;
 		setup.StoryEvents.emit(setup.StoryEvents.Event.CHEAT_USED, { source: source });
-	}
+	};
+    Setting.addList("timeFormat", {
+        label   : "Display Format for Time",
+        list    : ["24 Hour", "12 Hour"],
+        default : "24 Hour",
+    });
+
 	Setting.addHeader(
 		"Cheats",
 		"Toggles + the ghost-type picker persist across reloads. The button list further down fires one-shot mutations on $state.variables — back/forward arrows can rewind those."

--- a/passages/gui/widgetInclude.tw
+++ b/passages/gui/widgetInclude.tw
@@ -60,7 +60,7 @@
 	<<repeat>> loop in setup.searchToolMarkup so every meter increment
 	advances the clock. Updates the clock display and tool-timer strip
 	(linkreplace doesn't trigger StoryCaption re-render) and routes to
-	the mode-aware hunt-over-time passage if the tick pushed dawn past 06:00. */
+	the mode-aware hunt-over-time passage if the tick pushed dawn past <<displayTime 0600>>. */
 	<<run setup.addTime(1)>>
 	<<replace "#time">><<= setup.Time.display()>><</replace>>
 	<<replace "#tool-timers">><<= setup.toolTimerHudMarkup()>><</replace>>

--- a/passages/gym/EmilyTalk.tw
+++ b/passages/gym/EmilyTalk.tw
@@ -21,7 +21,7 @@
 	<</if>>
 
 	<<if _check eq 3>>
-		@@.notmc-speech; There are group classes here, held daily from 12:00 to 14:00. They are free and very effective.<br>@@
+		@@.notmc-speech; There are group classes here, held daily from <<displayTime 1200>> to <<displayTime 1400>>. They are free and very effective.<br>@@
 		@@.mc-speech; Thanks for mentioning it. I'll keep that in mind.<br>@@
 	<</if>>
 	<<if setup.Gym.raiseEmilyRelationship()>>

--- a/passages/gym/Gym.tw
+++ b/passages/gym/Gym.tw
@@ -6,7 +6,7 @@
 @@<br>
 <br>
 <<if not setup.Gym.isOpen()>>
-	@@.mc-thoughts; The gym is not open right now (open from 08:00 to 22:00)@@
+	@@.mc-thoughts; The gym is not open right now (open from <<displayTime 0800>> to <<displayTime 2200>>)@@
 <<else>>
 	@@.enterbtn;[[Inside|GymInside]]@@
 <</if>>

--- a/passages/mall/Mall.tw
+++ b/passages/mall/Mall.tw
@@ -5,7 +5,7 @@
 @@<br>
 <br>
 <<if not setup.Mall.isOpen()>>
-	@@.mc-thoughts;The mall is not open right now (open from 08:00 to 22:00)@@
+	@@.mc-thoughts;The mall is not open right now (open from <<displayTime 0800>> to <<displayTime 2200>>)@@
 <<else>>
 	@@.enterbtn;[[Clothing section|ClothingSection]]@@<br>
 	@@.enterbtn;[[General merchandise|GeneralSection]]@@<br>

--- a/passages/missing_women/RescueHouse.tw
+++ b/passages/missing_women/RescueHouse.tw
@@ -18,7 +18,7 @@
 <</if>>
 <<addTime 20>>
 <<if setup.MissingWomen.searchTooLate()>>
-	@@.mc-speech; The nun said that after 18:00 it's pointless to keep searching. It seems I'm too late. I should go back to her and tell her I failed.@@<br>
+	@@.mc-speech; The nun said that after <<displayTime 1800>> it's pointless to keep searching. It seems I'm too late. I should go back to her and tell her I failed.@@<br>
 <<else>>
 	<<if setup.MissingWomen.canSearchHouse()>>
 		<<linkreplace '@@.usebtn; Search the house @@ <<statIcon setup.StatIcon.ENERGY>>'>>
@@ -29,7 +29,7 @@
 			<<elseif setup.MissingWomen.canResolveRescue()>>
 				<<goto "RescueEvent">>
 			<<elseif setup.MissingWomen.questFailed()>>
-				@@.mc-speech; The nun said that after 18:00 it's pointless to keep searching. It seems I'm too late. I should go back to her and tell her I failed.@@<br>
+				@@.mc-speech; The nun said that after <<displayTime 1800>> it's pointless to keep searching. It seems I'm too late. I should go back to her and tell her I failed.@@<br>
 			<<else>>
 				@@.mc-thoughts; You search around but can't find anything yet. Maybe you should come back later.@@
 			<</if>>

--- a/passages/missing_women/RescueTaskBoard.tw
+++ b/passages/missing_women/RescueTaskBoard.tw
@@ -29,7 +29,7 @@
 	<<elseif setup.MissingWomen.hasActiveQuest()>>
 		@@.mc-speech; I've already taken the missing poster for <<= setup.MissingWomen.currentRescueGirl()>>, I need to find her first.@@<br>
 	<<elseif setup.MissingWomen.isQuestAvailable()>>
-		@@.mc-speech; The nun said that the missing posters appear in the evening, around 18:00.@@<br>
+		@@.mc-speech; The nun said that the missing posters appear in the evening, around <<displayTime 1800>>.@@<br>
 	<<elseif setup.MissingWomen.mustReturnToNun()>>
 		@@.mc-speech;First, I need to go see the nun. She should be at the church. @@
 	<</if>>

--- a/passages/salon/BeautySalon.tw
+++ b/passages/salon/BeautySalon.tw
@@ -5,7 +5,7 @@
 @@.mc-thoughts; The beauty salon is a place where you can enhance your uniqueness and style. For now, only piercing services are available, but more options are promised in the future!@@<br>
 <br>
 <<if not setup.Salon.isOpen()>>
-	@@.mc-thoughts;Beauty Salon is not open right now (open from 08:00 to 22:00)@@<br>
+	@@.mc-thoughts;Beauty Salon is not open right now (open from <<displayTime 0800>> to <<displayTime 2200>>)@@<br>
 <<else>>
 	<span class="enterbtn">[[Go inside|BeautySalonInside]]</span><br>
 <</if>>

--- a/passages/time/TimeDisplay.js
+++ b/passages/time/TimeDisplay.js
@@ -14,16 +14,17 @@
             if(!(min >= 0 && min <= 59) && (hour >= 0 && hour <=23)) {
                 return this.error('The Value of `<<displayTime>>` on Passage: '+ SugarCube.State.passage + " is out of bounds! Value: '"+ this.args[0] + "'");
             }
-            
+
+            const timeFormat = SugarCube.settings?.timeFormat || settings?.timeFormat || "24 Hour";
             let displayMin = String(min).padStart(2, "0");
 
-            if (SugarCube.settings.timeFormat == "24 Hour") {
+            if (timeFormat == "24 Hour") {
                 let displayHour = String(hour).padStart(2, "0");
 
                 this.output.append(displayHour + ":" + displayMin);
             }
 
-            if (SugarCube.settings.timeFormat == "12 Hour") {
+            if (timeFormat == "12 Hour") {
                 let suffix = hour >= 12 ? "PM" : "AM";
                 let displayHour = hour % 12 || 12;
 

--- a/passages/time/TimeDisplay.js
+++ b/passages/time/TimeDisplay.js
@@ -1,0 +1,34 @@
+(function() {
+    Macro.add('displayTime', {
+        handler : function () {
+
+             if (this.args.length != 1) {
+                return this.error('The `<<displayTime>>` macro requires a Time to be displayed written in the 24h Military Format (0830)');
+            }
+
+            if (!Number.isInteger(this.args[0])) {
+                return this.error('The `<<displayTime>>` on Passage: '+ SugarCube.State.passage + " Has a Wrong Time input: '"+ this.args[0] + "'");
+            }
+            let min = this.args[0] % 100 
+            let hour = Math.floor(this.args[0] / 100)
+            if(!(min >= 0 && min <= 59) && (hour >= 0 && hour <=23)) {
+                return this.error('The Value of `<<displayTime>>` on Passage: '+ SugarCube.State.passage + " is out of bounds! Value: '"+ this.args[0] + "'");
+            }
+            
+            let displayMin = String(min).padStart(2, "0");
+
+            if (SugarCube.settings.timeFormat == "24 Hour") {
+                let displayHour = String(hour).padStart(2, "0");
+
+                this.output.append(displayHour + ":" + displayMin);
+            }
+
+            if (SugarCube.settings.timeFormat == "12 Hour") {
+                let suffix = hour >= 12 ? "PM" : "AM";
+                let displayHour = hour % 12 || 12;
+
+                this.output.append(displayHour + ":" + displayMin + " " + suffix);
+            }
+        }
+    }) 
+}());


### PR DESCRIPTION
PR for Issue https://github.com/almostanonymousdev/ghost-in-m-sheet/issues/55

Added a new Macro in TimeFormat.js to allow a standardized method of displaying Time in the game.

Macro works by reading in a Military based Time from 0000 to 2359 and displaying the equivalent of 24 Hour or 12 Hour depending on the Players Settings.

2400 is not allowed as its duped with 0000. Integers outside this Range will throw an Error, aswell as invalid Parameters and or a time that is not possible 0072. 72 > 59 


1800 would result in:
18:00 | 06:00 PM

0800 would result in:
08:00 | 08:00 AM